### PR TITLE
Improve responsive behaviour across input types

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,10 +37,14 @@
   window.addEventListener('scroll', onScroll);
 
   // Custom cursor
-  window.addEventListener('mousemove', (e) => {
-    if (!cursor) return;
-    cursor.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
-  });
+  const hasFinePointer = window.matchMedia('(pointer: fine)').matches;
+  if (hasFinePointer && cursor){
+    window.addEventListener('mousemove', (e) => {
+      cursor.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
+    });
+  } else if (cursor){
+    cursor.remove();
+  }
 
   // SFX (WebAudio)
   let audioCtx = null;
@@ -71,62 +75,73 @@
   backToTop && backToTop.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
 
   // Particles
-  const DPR = Math.max(1, window.devicePixelRatio || 1);
-  const ctx = particles.getContext('2d');
-  const P = Array.from({ length: 80 }).map(() => ({
-    x: Math.random(), y: Math.random(),
-    vx: (Math.random()-0.5)*0.0008, vy: (Math.random()-0.5)*0.0008,
-    r: 1 + Math.random()*2
-  }));
-  const resize = () => { particles.width = particles.clientWidth * DPR; particles.height = particles.clientHeight * DPR; };
-  resize(); window.addEventListener('resize', resize);
-  const loop = () => {
-    const w = particles.width, h = particles.height;
-    ctx.clearRect(0,0,w,h);
-    const grd = ctx.createLinearGradient(0,0,w,h);
-    grd.addColorStop(0, '#0b0114'); grd.addColorStop(1,'#12021c');
-    ctx.fillStyle = grd; ctx.fillRect(0,0,w,h);
-    P.forEach(p => {
-      p.x += p.vx; p.y += p.vy;
-      if (p.x < 0 || p.x > 1) p.vx *= -1;
-      if (p.y < 0 || p.y > 1) p.vy *= -1;
-      const px = p.x * w, py = p.y * h;
-      ctx.beginPath(); ctx.arc(px, py, p.r*DPR, 0, Math.PI*2);
-      ctx.fillStyle = 'rgba(155,93,229,0.7)'; ctx.fill();
-    });
-    // lines
-    for (let i=0;i<P.length;i++){
-      for (let j=i+1;j<P.length;j++){
-        const a=P[i], b=P[j];
-        const dx=(a.x-b.x)*w, dy=(a.y-b.y)*h;
-        const dist=Math.hypot(dx,dy);
-        if (dist < 150){
-          ctx.strokeStyle='rgba(123,47,247,0.15)'; ctx.lineWidth=1;
-          ctx.beginPath(); ctx.moveTo(a.x*w,a.y*h); ctx.lineTo(b.x*w,b.y*h); ctx.stroke();
+  if (particles){
+    const ctx = particles.getContext('2d');
+    if (ctx){
+      const DPR = Math.max(1, window.devicePixelRatio || 1);
+      const P = Array.from({ length: hasFinePointer ? 80 : 50 }).map(() => ({
+        x: Math.random(), y: Math.random(),
+        vx: (Math.random()-0.5)*0.0008, vy: (Math.random()-0.5)*0.0008,
+        r: 1 + Math.random()*2
+      }));
+      const resize = () => {
+        particles.width = particles.clientWidth * DPR;
+        particles.height = particles.clientHeight * DPR;
+      };
+      resize();
+      window.addEventListener('resize', resize);
+      const loop = () => {
+        const w = particles.width, h = particles.height;
+        ctx.clearRect(0,0,w,h);
+        const grd = ctx.createLinearGradient(0,0,w,h);
+        grd.addColorStop(0, '#0b0114'); grd.addColorStop(1,'#12021c');
+        ctx.fillStyle = grd; ctx.fillRect(0,0,w,h);
+        P.forEach(p => {
+          p.x += p.vx; p.y += p.vy;
+          if (p.x < 0 || p.x > 1) p.vx *= -1;
+          if (p.y < 0 || p.y > 1) p.vy *= -1;
+          const px = p.x * w, py = p.y * h;
+          ctx.beginPath(); ctx.arc(px, py, p.r*DPR, 0, Math.PI*2);
+          ctx.fillStyle = 'rgba(155,93,229,0.7)'; ctx.fill();
+        });
+        for (let i=0;i<P.length;i++){
+          for (let j=i+1;j<P.length;j++){
+            const a=P[i], b=P[j];
+            const dx=(a.x-b.x)*w, dy=(a.y-b.y)*h;
+            const dist=Math.hypot(dx,dy);
+            if (dist < 150){
+              ctx.strokeStyle='rgba(123,47,247,0.15)'; ctx.lineWidth=1;
+              ctx.beginPath(); ctx.moveTo(a.x*w,a.y*h); ctx.lineTo(b.x*w,b.y*h); ctx.stroke();
+            }
+          }
         }
-      }
+        requestAnimationFrame(loop);
+      };
+      loop();
     }
-    requestAnimationFrame(loop);
-  };
-  loop();
+  }
 
   // Card tilt
-  $$('.card3d').forEach(card => {
-    card.addEventListener('mousemove', (e) => {
-      const rect = card.getBoundingClientRect();
-      const px = (e.clientX - rect.left) / rect.width;
-      const py = (e.clientY - rect.top) / rect.height;
-      const ry = (px - 0.5) * 10;
-      const rx = (0.5 - py) * 10;
-      card.style.transform = `perspective(800px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+  const allowTilt = hasFinePointer && window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+  if (allowTilt){
+    $$('.card3d').forEach(card => {
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const px = (e.clientX - rect.left) / rect.width;
+        const py = (e.clientY - rect.top) / rect.height;
+        const ry = (px - 0.5) * 10;
+        const rx = (0.5 - py) * 10;
+        card.style.transform = `perspective(800px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.transform = 'perspective(800px) rotateX(0deg) rotateY(0deg)';
+      });
     });
-    card.addEventListener('mouseleave', () => {
-      card.style.transform = 'perspective(800px) rotateX(0deg) rotateY(0deg)';
-    });
-  });
+  }
 
   // Carousel controls
   const scrollByCard = (track, dir=1) => {
+    if (!track) return;
     const card = track.querySelector('[data-card]');
     const amount = card ? card.clientWidth + 16 : 320;
     track.scrollBy({ left: amount * dir, behavior:'smooth' });

--- a/style.css
+++ b/style.css
@@ -5,7 +5,22 @@
 }
 
 body {
-cursor: none;
+  cursor: none;
+  line-height: 1.55;
+}
+
+/* Improve anchor scroll positioning when navbar is fixed */
+section[id] {
+  scroll-margin-top: clamp(4.5rem, 8vh, 6.5rem);
+}
+
+#cursor {
+  transition: transform .12s ease-out;
+}
+
+@media (pointer: coarse) {
+  body { cursor: auto; }
+  #cursor { display: none; }
 }
 
 /* Scrollbar hidden util */
@@ -16,9 +31,9 @@ cursor: none;
 .sticky-nav{ background: rgba(0,0,0,.8); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.1); }
 
 /* Card 3D styles */
-.card3d{ position:relative; width:320px; max-width:360px; background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.1); border-radius:1rem; overflow:hidden; transition:transform .15s ease, background .2s ease; }
+.card3d{ position:relative; width:clamp(260px, 70vw, 340px); background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.1); border-radius:1rem; overflow:hidden; transition:transform .15s ease, background .2s ease; scroll-snap-align:start; }
 .card3d:hover{ background:rgba(255,255,255,.08); }
-.card3d-img{ position:relative; height:180px; background:rgba(0,0,0,.3); }
+.card3d-img{ position:relative; background:rgba(0,0,0,.3); aspect-ratio:16/9; }
 .card3d-img img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:.75; }
 .card3d-title{ font-weight:600; font-size:1.125rem; color:#e9d5ff; }
 .card3d-desc{ font-size:.9rem; color:rgba(255,255,255,.75); margin-top:.25rem; }
@@ -30,6 +45,8 @@ cursor: none;
 .carousel-controls{ position:absolute; inset:0; display:flex; align-items:center; justify-content:space-between; pointer-events:none; padding:0 .25rem; }
 .carousel-controls button{ pointer-events:auto; height:40px; width:40px; border-radius:9999px; background:rgba(255,255,255,.1); border:1px solid rgba(255,255,255,.2); backdrop-filter: blur(8px); }
 .carousel-controls button:hover{ background:rgba(255,255,255,.2); }
+
+#gamesTrack, #pluginsTrack{ scroll-snap-type:x proximity; padding-bottom:.5rem; }
 
 /* News cards */
 .news-card{ border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:linear-gradient(135deg, rgba(255,255,255,.05), transparent); }
@@ -64,10 +81,21 @@ cursor: none;
 /* Responsive Cards */
 @media (max-width: 640px){
   .card3d{ width:88vw; }
-  .card3d-img{ height:160px; }
 }
 
 /* Buttons full width on mobile */
 @media (max-width: 640px){
   .btn-primary, .btn-outline{ width:100%; text-align:center }
+}
+
+@media (max-width: 640px){
+  .carousel-controls{ display:none; }
+}
+
+@media (min-width: 1024px){
+  #gamesTrack, #pluginsTrack{ justify-content:center; }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .card3d{ transition: background .2s ease; }
 }


### PR DESCRIPTION
## Summary
- adjust layout tokens and carousel styles to better fit narrow viewports and avoid the fixed navbar covering anchors
- hide the custom cursor and tilt effects on touch devices while keeping cards sized with clamp-based widths and scroll snapping
- guard particle animation logic for devices without fine pointers and center carousels on large screens

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68e2d16e0ba4832f9850f854c4cb5e0d