### PR TITLE
Invert light theme sticky buttons and hero overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,10 +45,10 @@
 
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="bg-black text-white selection:bg-purple-500/30 antialiased overflow-x-hidden">
+<body class="theme-dark selection:bg-purple-500/30 antialiased overflow-x-hidden">
 
   <!-- Custom Cursor -->
-  <div id="cursor" class="pointer-events-none fixed left-0 top-0 z-[9999] -translate-x-1/2 -translate-y-1/2 h-6 w-6 rounded-full border border-purple-400/60 shadow-glow" aria-hidden="true"></div>
+  <div id="cursor" class="pointer-events-none fixed left-0 top-0 z-[9999] -translate-x-1/2 -translate-y-1/2 h-4 w-4 rounded-full border border-purple-400/60 shadow-glow" aria-hidden="true"></div>
 
   <!-- Navbar -->
   <header id="navbar" class="fixed top-0 w-full z-50 transition-colors">
@@ -72,6 +72,7 @@
       <!-- Mobile controls -->
       <div class="flex items-center gap-3">
         <button id="muteBtn" class="hidden md:inline-block px-3 py-1.5 rounded-md text-xs border border-white/15 hover:border-purple-400/50 hover:text-purple-300" aria-label="Toggle SFX">Unmute SFX</button>
+        <button id="themeToggle" class="hidden md:inline-block px-3 py-1.5 rounded-md text-xs border border-white/15 hover:border-purple-400/50 hover:text-purple-300" aria-label="Toggle color theme">Light Mode</button>
         <button id="hamburger" class="md:hidden h-9 w-9 grid place-items-center border border-white/20 rounded" aria-label="Open menu" aria-expanded="false">
           <span class="hamburger-line"></span>
           <span class="hamburger-line"></span>
@@ -90,18 +91,19 @@
       <a href="#team">Team</a>
       <a href="#contact">Contact</a>
       <button id="muteBtnMobile" class="mt-2 px-3 py-1.5 rounded-md text-xs border border-white/15">Unmute SFX</button>
+      <button id="themeToggleMobile" class="mt-2 px-3 py-1.5 rounded-md text-xs border border-white/15">Light Mode</button>
     </div>
   </header>
 
   <!-- Hero with Particles -->
   <section id="home" class="relative h-[78vh] sm:h-[88vh] grid place-items-center overflow-hidden">
     <canvas id="particles" class="absolute inset-0 w-full h-full"></canvas>
-    <div class="absolute inset-0 bg-gradient-to-b from-transparent via-black/30 to-black"></div>
+    <div class="hero-overlay absolute inset-0"></div>
     <div class="relative z-10 text-center px-4 sm:px-6" id="heroContent">
       <h1 class="text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight">
         Creating Worlds. <span class="text-purpleNeo">Inspiring Players.</span>
       </h1>
-      <p class="mt-4 text-sm sm:text-base md:text-lg text-white/80 max-w-2xl mx-auto">
+      <p class="hero-tagline mt-4 text-sm sm:text-base md:text-lg max-w-2xl mx-auto">
         Brazilian game studio crafting immersive experiences with technology, creativity and passion.
       </p>
       <div class="mt-8 flex flex-wrap justify-center gap-3">
@@ -117,7 +119,7 @@
       <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6">Our Games</h2>
       <p class="text-white/60 mb-6 max-w-3xl">Worlds built with heart and cutting-edge tech. Drag to explore.</p>
       <div class="relative">
-        <div id="gamesTrack" class="flex gap-4 overflow-x-auto no-scrollbar pb-2">
+        <div id="gamesTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
           <div class="card3d" data-card>
             <div class="card3d-img"><img src="img/frontline.png" alt="Frontline on Steam" /></div>
             <div class="p-5">
@@ -167,7 +169,7 @@
         <span class="text-xs text-purple-300/70">Fab marketplace listings</span>
       </div>
       <div class="relative">
-        <div id="pluginsTrack" class="flex gap-4 overflow-x-auto no-scrollbar pb-2">
+        <div id="pluginsTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
           <div class="card3d" data-card>
             <div class="card3d-img"><img src="img/WorldProceduralGeneratorPlugin.jpg" alt="World Procedural Generator Plugin cover" /></div>
             <div class="p-5">

--- a/script.js
+++ b/script.js
@@ -14,6 +14,10 @@
   const muteBtnMobile = $('#muteBtnMobile');
   const mobileMenu = $('#mobileMenu');
   const hamburger = $('#hamburger');
+  const themeToggle = $('#themeToggle');
+  const themeToggleMobile = $('#themeToggleMobile');
+  const metaTheme = document.querySelector('meta[name="theme-color"]');
+  const prefersLight = window.matchMedia('(prefers-color-scheme: light)');
   const contactForm = $('#contactForm');
   const formFeedback = $('#formFeedback');
   const yearSpan = $('#year');
@@ -27,6 +31,58 @@
   refreshMuteBtn();
   if (sfxToggle) sfxToggle.checked = !muted;
 
+  // Theme toggling
+  const storage = (() => {
+    try { return window.localStorage; } catch (err) { return null; }
+  })();
+  const THEME_KEY = 'neo-theme';
+  let userSelectedTheme = false;
+  let theme = prefersLight.matches ? 'light' : 'dark';
+  if (storage){
+    try {
+      const saved = storage.getItem(THEME_KEY);
+      if (saved === 'light' || saved === 'dark'){
+        theme = saved;
+        userSelectedTheme = true;
+      }
+    } catch (err) {
+      console.warn('Theme storage unavailable', err);
+    }
+  }
+
+  const applyTheme = (next, fromUser=false) => {
+    theme = next === 'light' ? 'light' : 'dark';
+    document.body.classList.toggle('theme-light', theme === 'light');
+    document.body.classList.toggle('theme-dark', theme !== 'light');
+    document.documentElement.style.colorScheme = theme === 'light' ? 'light' : 'dark';
+    const label = theme === 'light' ? 'Dark Mode' : 'Light Mode';
+    if (themeToggle) themeToggle.textContent = label;
+    if (themeToggleMobile) themeToggleMobile.textContent = label;
+    if (metaTheme) metaTheme.setAttribute('content', theme === 'light' ? '#f6f3ff' : '#12021c');
+    if (storage && (fromUser || userSelectedTheme)){
+      try { storage.setItem(THEME_KEY, theme); } catch (err) { console.warn('Theme storage failed', err); }
+    }
+    if (fromUser) userSelectedTheme = true;
+  };
+
+  applyTheme(theme, userSelectedTheme);
+
+  const toggleTheme = () => applyTheme(theme === 'light' ? 'dark' : 'light', true);
+  themeToggle && themeToggle.addEventListener('click', toggleTheme);
+  themeToggleMobile && themeToggleMobile.addEventListener('click', () => {
+    toggleTheme();
+    if (mobileMenu) mobileMenu.classList.add('hidden');
+    if (hamburger) hamburger.setAttribute('aria-expanded', 'false');
+  });
+
+  const handleSystemTheme = (event) => {
+    if (userSelectedTheme) return;
+    applyTheme(event.matches ? 'light' : 'dark');
+  };
+
+  if (prefersLight.addEventListener) prefersLight.addEventListener('change', handleSystemTheme);
+  else if (prefersLight.addListener) prefersLight.addListener(handleSystemTheme);
+
   // Navbar scroll / back-to-top
   const onScroll = () => {
     const y = window.scrollY;
@@ -37,10 +93,33 @@
   window.addEventListener('scroll', onScroll);
 
   // Custom cursor
-  window.addEventListener('mousemove', (e) => {
-    if (!cursor) return;
-    cursor.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
-  });
+  const hasFinePointer = window.matchMedia('(pointer: fine)').matches;
+  const isMobileViewport = window.matchMedia('(max-width: 768px)').matches;
+  const enableCustomCursor = hasFinePointer && !isMobileViewport;
+  if (cursor){
+    if (enableCustomCursor){
+      document.body.classList.add('custom-cursor-active');
+      let cursorVisible = false;
+      const reveal = () => {
+        if (!cursorVisible){
+          cursor.style.opacity = '1';
+          cursorVisible = true;
+        }
+      };
+      const hideCursor = () => {
+        cursorVisible = false;
+        cursor.style.opacity = '0';
+      };
+      window.addEventListener('mousemove', (e) => {
+        reveal();
+        cursor.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
+      });
+      window.addEventListener('mouseleave', hideCursor);
+
+    } else {
+      cursor.remove();
+    }
+  }
 
   // SFX (WebAudio)
   let audioCtx = null;
@@ -71,62 +150,73 @@
   backToTop && backToTop.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
 
   // Particles
-  const DPR = Math.max(1, window.devicePixelRatio || 1);
-  const ctx = particles.getContext('2d');
-  const P = Array.from({ length: 80 }).map(() => ({
-    x: Math.random(), y: Math.random(),
-    vx: (Math.random()-0.5)*0.0008, vy: (Math.random()-0.5)*0.0008,
-    r: 1 + Math.random()*2
-  }));
-  const resize = () => { particles.width = particles.clientWidth * DPR; particles.height = particles.clientHeight * DPR; };
-  resize(); window.addEventListener('resize', resize);
-  const loop = () => {
-    const w = particles.width, h = particles.height;
-    ctx.clearRect(0,0,w,h);
-    const grd = ctx.createLinearGradient(0,0,w,h);
-    grd.addColorStop(0, '#0b0114'); grd.addColorStop(1,'#12021c');
-    ctx.fillStyle = grd; ctx.fillRect(0,0,w,h);
-    P.forEach(p => {
-      p.x += p.vx; p.y += p.vy;
-      if (p.x < 0 || p.x > 1) p.vx *= -1;
-      if (p.y < 0 || p.y > 1) p.vy *= -1;
-      const px = p.x * w, py = p.y * h;
-      ctx.beginPath(); ctx.arc(px, py, p.r*DPR, 0, Math.PI*2);
-      ctx.fillStyle = 'rgba(155,93,229,0.7)'; ctx.fill();
-    });
-    // lines
-    for (let i=0;i<P.length;i++){
-      for (let j=i+1;j<P.length;j++){
-        const a=P[i], b=P[j];
-        const dx=(a.x-b.x)*w, dy=(a.y-b.y)*h;
-        const dist=Math.hypot(dx,dy);
-        if (dist < 150){
-          ctx.strokeStyle='rgba(123,47,247,0.15)'; ctx.lineWidth=1;
-          ctx.beginPath(); ctx.moveTo(a.x*w,a.y*h); ctx.lineTo(b.x*w,b.y*h); ctx.stroke();
+  if (particles){
+    const ctx = particles.getContext('2d');
+    if (ctx){
+      const DPR = Math.max(1, window.devicePixelRatio || 1);
+      const P = Array.from({ length: hasFinePointer ? 80 : 50 }).map(() => ({
+        x: Math.random(), y: Math.random(),
+        vx: (Math.random()-0.5)*0.0008, vy: (Math.random()-0.5)*0.0008,
+        r: 1 + Math.random()*2
+      }));
+      const resize = () => {
+        particles.width = particles.clientWidth * DPR;
+        particles.height = particles.clientHeight * DPR;
+      };
+      resize();
+      window.addEventListener('resize', resize);
+      const loop = () => {
+        const w = particles.width, h = particles.height;
+        ctx.clearRect(0,0,w,h);
+        const grd = ctx.createLinearGradient(0,0,w,h);
+        grd.addColorStop(0, '#0b0114'); grd.addColorStop(1,'#12021c');
+        ctx.fillStyle = grd; ctx.fillRect(0,0,w,h);
+        P.forEach(p => {
+          p.x += p.vx; p.y += p.vy;
+          if (p.x < 0 || p.x > 1) p.vx *= -1;
+          if (p.y < 0 || p.y > 1) p.vy *= -1;
+          const px = p.x * w, py = p.y * h;
+          ctx.beginPath(); ctx.arc(px, py, p.r*DPR, 0, Math.PI*2);
+          ctx.fillStyle = 'rgba(155,93,229,0.7)'; ctx.fill();
+        });
+        for (let i=0;i<P.length;i++){
+          for (let j=i+1;j<P.length;j++){
+            const a=P[i], b=P[j];
+            const dx=(a.x-b.x)*w, dy=(a.y-b.y)*h;
+            const dist=Math.hypot(dx,dy);
+            if (dist < 150){
+              ctx.strokeStyle='rgba(123,47,247,0.15)'; ctx.lineWidth=1;
+              ctx.beginPath(); ctx.moveTo(a.x*w,a.y*h); ctx.lineTo(b.x*w,b.y*h); ctx.stroke();
+            }
+          }
         }
-      }
+        requestAnimationFrame(loop);
+      };
+      loop();
     }
-    requestAnimationFrame(loop);
-  };
-  loop();
+  }
 
   // Card tilt
-  $$('.card3d').forEach(card => {
-    card.addEventListener('mousemove', (e) => {
-      const rect = card.getBoundingClientRect();
-      const px = (e.clientX - rect.left) / rect.width;
-      const py = (e.clientY - rect.top) / rect.height;
-      const ry = (px - 0.5) * 10;
-      const rx = (0.5 - py) * 10;
-      card.style.transform = `perspective(800px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+  const allowTilt = hasFinePointer && window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+  if (allowTilt){
+    $$('.card3d').forEach(card => {
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const px = (e.clientX - rect.left) / rect.width;
+        const py = (e.clientY - rect.top) / rect.height;
+        const ry = (px - 0.5) * 10;
+        const rx = (0.5 - py) * 10;
+        card.style.transform = `perspective(800px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.transform = 'perspective(800px) rotateX(0deg) rotateY(0deg)';
+      });
     });
-    card.addEventListener('mouseleave', () => {
-      card.style.transform = 'perspective(800px) rotateX(0deg) rotateY(0deg)';
-    });
-  });
+  }
 
   // Carousel controls
   const scrollByCard = (track, dir=1) => {
+    if (!track) return;
     const card = track.querySelector('[data-card]');
     const amount = card ? card.clientWidth + 16 : 320;
     track.scrollBy({ left: amount * dir, behavior:'smooth' });

--- a/style.css
+++ b/style.css
@@ -1,73 +1,307 @@
-/* Neo Soft — styles (dark theme, purple highlights) */
+/* Neo Soft — styles (dark & light themes) */
 :root{
   --purple:#9b5de5;
   --fuchsia:#d14bf0;
 }
 
-body {
-cursor: none;
+body.theme-dark{
+  --bg-body:#050009;
+  --nav-bg:rgba(0,0,0,.8);
+  --nav-border:rgba(255,255,255,.1);
+  --text-primary:#fdfbff;
+  --text-secondary:rgba(232,223,255,.78);
+  --text-muted:rgba(207,197,245,.6);
+  --accent-strong:#d6bcfa;
+  --accent-soft:#c4b5fd;
+  --border-subtle:rgba(255,255,255,.1);
+  --border-soft:rgba(255,255,255,.15);
+  --border-strong:rgba(255,255,255,.2);
+  --surface:rgba(255,255,255,.05);
+  --surface-strong:#0b0114;
+  --surface-alt:#000000;
+  --card-bg:rgba(255,255,255,.05);
+  --card-hover:rgba(255,255,255,.08);
+  --card-border:rgba(255,255,255,.1);
+  --card-img-overlay:rgba(0,0,0,.3);
+  --shadow-glow:rgba(155,93,229,.5);
+  --news-bg:linear-gradient(135deg, rgba(255,255,255,.05), transparent);
+  --team-card-bg:rgba(255,255,255,.05);
+  --team-card-hover:rgba(255,255,255,.1);
+  --form-bg:rgba(255,255,255,.05);
+  --input-border:rgba(255,255,255,.15);
+  --input-placeholder:rgba(255,255,255,.4);
+  --btn-outline-border:rgba(255,255,255,.2);
+  --btn-outline-hover:rgba(216,180,254,.6);
+  --btn-outline-text:#fdfbff;
+  --btn-primary-shadow:rgba(155,93,229,.2);
+  --footer-bg:#000000;
+  --footer-text:rgba(255,255,255,.6);
+  --footer-link-hover:#d6bcfa;
+  --mobile-menu-bg:rgba(0,0,0,.9);
+  --mobile-menu-border:rgba(255,255,255,.12);
+  --carousel-button-bg:rgba(255,255,255,.1);
+  --carousel-button-hover:rgba(255,255,255,.2);
+  --section-games-bg:linear-gradient(to bottom, #000000, #0b0114, #000000);
+  --section-plugins-bg:#0b0114;
+  --section-news-bg:#000000;
+  --section-careers-bg:linear-gradient(to bottom, #0b0114, #000000);
+  --section-about-bg:#000000;
+  --section-team-bg:#0b0114;
+  --section-contact-bg:#000000;
+}
+
+body.theme-light{
+  --bg-body:#f6f3ff;
+  --nav-bg:rgba(247,243,255,.9);
+  --nav-border:rgba(101,79,182,.25);
+  --text-primary:#1a1033;
+  --text-secondary:rgba(46,32,85,.8);
+  --text-muted:rgba(66,54,104,.65);
+  --accent-strong:#5b3ce1;
+  --accent-soft:#7356f5;
+  --border-subtle:rgba(101,79,182,.25);
+  --border-soft:rgba(101,79,182,.35);
+  --border-strong:rgba(101,79,182,.45);
+  --surface:rgba(96,77,191,.08);
+  --surface-strong:#ffffff;
+  --surface-alt:#f0ecff;
+  --card-bg:#ffffff;
+  --card-hover:#f5f1ff;
+  --card-border:rgba(101,79,182,.25);
+  --card-img-overlay:rgba(255,255,255,.55);
+  --shadow-glow:rgba(96,77,191,.35);
+  --news-bg:linear-gradient(135deg, rgba(108,94,175,.12), rgba(246,244,255,.95));
+  --team-card-bg:rgba(255,255,255,.88);
+  --team-card-hover:#ffffff;
+  --form-bg:rgba(255,255,255,.92);
+  --input-border:rgba(101,79,182,.35);
+  --input-placeholder:rgba(66,54,104,.45);
+  --btn-outline-border:rgba(101,79,182,.45);
+  --btn-outline-hover:#5b3ce1;
+  --btn-outline-text:#1a1033;
+  --btn-primary-shadow:rgba(96,77,191,.18);
+  --footer-bg:#f2edff;
+  --footer-text:rgba(46,32,85,.7);
+  --footer-link-hover:#5b3ce1;
+  --mobile-menu-bg:rgba(247,243,255,.95);
+  --mobile-menu-border:rgba(101,79,182,.3);
+  --carousel-button-bg:rgba(96,77,191,.12);
+  --carousel-button-hover:rgba(96,77,191,.24);
+  --section-games-bg:linear-gradient(to bottom, #f3efff, #ffffff);
+  --section-plugins-bg:#f6f3ff;
+  --section-news-bg:#fdfcff;
+  --section-careers-bg:linear-gradient(to bottom, #f6f3ff, #ffffff);
+  --section-about-bg:#ffffff;
+  --section-team-bg:#f6f3ff;
+  --section-contact-bg:#ffffff;
+}
+
+body{
+  line-height:1.55;
+  background-color:var(--bg-body);
+  color:var(--text-primary);
+  transition:background-color .3s ease, color .3s ease;
+}
+
+body.custom-cursor-active,
+body.custom-cursor-active *{
+  cursor:none !important;
+}
+
+.hero-overlay{
+  transition:background .3s ease;
+}
+
+body.theme-dark .hero-overlay{
+  background:linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,.35), rgba(0,0,0,.82));
+}
+
+body.theme-light .hero-overlay{
+  background:linear-gradient(to bottom, rgba(255,255,255,.25), rgba(255,255,255,.8), rgba(0,0,0,.6));
+}
+
+.hero-tagline{
+  color:rgba(255,255,255,.8);
+  transition:color .3s ease;
+}
+
+body.theme-light .hero-tagline{
+  color:rgba(12,8,28,.85);
+}
+
+/* Improve anchor scroll positioning when navbar is fixed */
+section[id]{
+  scroll-margin-top:clamp(4.5rem, 8vh, 6.5rem);
+}
+
+#cursor{
+  opacity:0;
+  transition:opacity .2s ease, transform .08s ease;
+  border-color:var(--accent-soft);
 }
 
 /* Scrollbar hidden util */
 .no-scrollbar{ scrollbar-width:none; }
 .no-scrollbar::-webkit-scrollbar{ display:none; }
 
-/* Navbar background on scroll */
-.sticky-nav{ background: rgba(0,0,0,.8); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.1); }
+/* Navbar states */
+#navbar{
+  color:#fff;
+  transition:color .3s ease;
+}
+#navbar a,
+#navbar button{
+  color:inherit;
+  transition:color .3s ease, border-color .3s ease, background-color .3s ease;
+}
+.sticky-nav{
+  background:var(--nav-bg);
+  backdrop-filter:blur(10px);
+  border-bottom:1px solid var(--nav-border);
+  color:var(--text-primary);
+}
+
+body.theme-light #navbar:not(.sticky-nav) .hamburger-line{
+  background:rgba(255,255,255,.85);
+}
+body.theme-light #navbar.sticky-nav .hamburger-line{
+  background:rgba(40,26,80,.85);
+}
+
+body.theme-light #navbar.sticky-nav #muteBtn,
+body.theme-light #navbar.sticky-nav #themeToggle{
+  border-color:var(--accent-strong);
+  background:var(--accent-strong);
+  color:#fff;
+}
+body.theme-light #navbar.sticky-nav #muteBtn:hover,
+body.theme-light #navbar.sticky-nav #themeToggle:hover{
+  background:var(--accent-soft);
+  border-color:var(--accent-soft);
+}
+
+body.theme-light #navbar.sticky-nav #hamburger{
+  border-color:var(--accent-strong);
+  background:var(--accent-strong);
+}
+
+body.theme-light #navbar.sticky-nav #hamburger .hamburger-line{
+  background:rgba(255,255,255,.9);
+}
+
+body.theme-light #navbar:not(.sticky-nav) #muteBtn,
+body.theme-light #navbar:not(.sticky-nav) #themeToggle,
+body.theme-light #navbar:not(.sticky-nav) #hamburger{
+  border-color:rgba(255,255,255,.35);
+  color:#fff;
+}
+
+/* Section backgrounds */
+#games{ background:var(--section-games-bg); }
+#plugins{ background:var(--section-plugins-bg); }
+#news{ background:var(--section-news-bg); }
+#careers{ background:var(--section-careers-bg); }
+#about{ background:var(--section-about-bg); }
+#team{ background:var(--section-team-bg); }
+#contact{ background:var(--section-contact-bg); }
 
 /* Card 3D styles */
-.card3d{ position:relative; width:320px; max-width:360px; background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.1); border-radius:1rem; overflow:hidden; transition:transform .15s ease, background .2s ease; }
-.card3d:hover{ background:rgba(255,255,255,.08); }
-.card3d-img{ position:relative; height:180px; background:rgba(0,0,0,.3); }
-.card3d-img img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:.75; }
-.card3d-title{ font-weight:600; font-size:1.125rem; color:#e9d5ff; }
-.card3d-desc{ font-size:.9rem; color:rgba(255,255,255,.75); margin-top:.25rem; }
-.card3d-link{ display:inline-block; margin-top:1rem; color:#d6bcfa; text-decoration:none; }
+.card3d{ position:relative; width:clamp(260px, 70vw, 340px); background:var(--card-bg); border:1px solid var(--card-border); border-radius:1rem; overflow:hidden; transition:transform .15s ease, background .2s ease, border-color .2s ease; scroll-snap-align:start; }
+.card3d:hover{ background:var(--card-hover); }
+.card3d-img{ position:relative; background:var(--card-img-overlay); aspect-ratio:16/9; }
+.card3d-img img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:.78; }
+.card3d-title{ font-weight:600; font-size:1.125rem; color:var(--accent-strong); }
+.card3d-desc{ font-size:.9rem; color:var(--text-secondary); margin-top:.25rem; }
+.card3d-link{ display:inline-block; margin-top:1rem; color:var(--accent-soft); text-decoration:none; font-weight:500; }
 .card3d-link:hover{text-decoration:underline;}
-.card3d::after{ content:''; position:absolute; inset:-1px; border-radius:1rem; box-shadow:0 0 60px rgba(155,93,229,.25); pointer-events:none; }
+.card3d::after{ content:''; position:absolute; inset:-1px; border-radius:1rem; box-shadow:0 0 60px rgba(0,0,0,0); pointer-events:none; transition:box-shadow .2s ease; }
+.card3d:hover::after{ box-shadow:0 0 60px var(--shadow-glow); }
 
 /* Carousel controls */
 .carousel-controls{ position:absolute; inset:0; display:flex; align-items:center; justify-content:space-between; pointer-events:none; padding:0 .25rem; }
-.carousel-controls button{ pointer-events:auto; height:40px; width:40px; border-radius:9999px; background:rgba(255,255,255,.1); border:1px solid rgba(255,255,255,.2); backdrop-filter: blur(8px); }
-.carousel-controls button:hover{ background:rgba(255,255,255,.2); }
+.carousel-controls button{ pointer-events:auto; height:40px; width:40px; border-radius:9999px; background:var(--carousel-button-bg); border:1px solid var(--border-strong); backdrop-filter:blur(8px); color:var(--text-primary); transition:background .2s ease, color .2s ease; }
+.carousel-controls button:hover{ background:var(--carousel-button-hover); }
+
+#gamesTrack, #pluginsTrack{ scroll-snap-type:x proximity; padding-bottom:.5rem; }
 
 /* News cards */
-.news-card{ border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:linear-gradient(135deg, rgba(255,255,255,.05), transparent); }
-.news-date{ font-size:.75rem; color:rgba(255,255,255,.6); }
-.news-title{ font-weight:700; font-size:1.25rem; color:#e9d5ff; margin:.25rem 0 .5rem; }
-.news-summary{ color:rgba(255,255,255,.85); font-size:.95rem; }
+.news-card{ border:1px solid var(--border-subtle); padding:1.5rem; border-radius:.75rem; background:var(--news-bg); transition:background .2s ease, border-color .2s ease; }
+.news-date{ font-size:.75rem; color:var(--text-muted); }
+.news-title{ font-weight:700; font-size:1.25rem; color:var(--accent-strong); margin:.25rem 0 .5rem; }
+.news-summary{ color:var(--text-secondary); font-size:.95rem; }
 
 /* Team */
-.team-card{ text-align:center; border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:rgba(255,255,255,.05); transition:background .2s ease; }
-.team-card:hover{ background:rgba(255,255,255,.1); }
-.team-avatar{ height:96px; width:96px; margin:0 auto 1rem; border-radius:9999px; background:linear-gradient(135deg, var(--purple), var(--fuchsia)); box-shadow:0 0 40px rgba(155,93,229,.35); }
-.team-name{ font-weight:600; }
-.team-role{ font-size:.85rem; color:rgba(216,180,254,.8); }
+.team-card{ text-align:center; border:1px solid var(--border-subtle); padding:1.5rem; border-radius:.75rem; background:var(--team-card-bg); transition:background .2s ease, border-color .2s ease; }
+.team-card:hover{ background:var(--team-card-hover); }
+.team-avatar{ height:96px; width:96px; margin:0 auto 1rem; border-radius:9999px; background:linear-gradient(135deg, var(--purple), var(--fuchsia)); box-shadow:0 0 40px var(--shadow-glow); }
+.team-name{ font-weight:600; color:var(--text-primary); }
+.team-role{ font-size:.85rem; color:var(--accent-soft); }
 
 /* Inputs / buttons */
-.input, .textarea{ border:1px solid rgba(255,255,255,.15); background:rgba(255,255,255,.05); border-radius:.5rem; padding:.6rem .75rem; color:white; }
-.input::placeholder, .textarea::placeholder{ color:rgba(255,255,255,.4); }
-.btn-primary{ padding:.7rem 1.25rem; border-radius:.5rem; font-weight:600; color:white; background:linear-gradient(90deg, var(--purple), var(--fuchsia)); box-shadow:0 10px 20px rgba(155,93,229,.2); }
+.input, .textarea{ border:1px solid var(--input-border); background:var(--form-bg); border-radius:.5rem; padding:.6rem .75rem; color:var(--text-primary); transition:border-color .2s ease, background .2s ease, color .2s ease; }
+.input::placeholder, .textarea::placeholder{ color:var(--input-placeholder); }
+.btn-primary{ display:inline-flex; align-items:center; justify-content:center; padding:.7rem 1.25rem; border-radius:.5rem; font-weight:600; color:white; background:linear-gradient(90deg, var(--purple), var(--fuchsia)); box-shadow:0 10px 20px var(--btn-primary-shadow); text-align:center; transition:transform .2s ease; }
 .btn-primary:hover{ filter:brightness(1.05); }
-.btn-outline{ padding:.7rem 1.25rem; border-radius:.5rem; border:1px solid rgba(255,255,255,.2); }
-.btn-outline:hover{ border-color: rgba(216,180,254,.6); color:#e9d5ff; }
+.btn-outline{ display:inline-flex; align-items:center; justify-content:center; padding:.7rem 1.25rem; border-radius:.5rem; border:1px solid var(--btn-outline-border); text-align:center; color:var(--btn-outline-text); transition:border-color .2s ease, color .2s ease, background .2s ease; background:transparent; }
+.btn-outline:hover{ border-color:var(--btn-outline-hover); color:var(--accent-strong); background:rgba(91,60,225,.08); }
 
 /* Custom shadow for cursor */
-.shadow-glow{ box-shadow:0 0 20px rgba(155,93,229,.5); }
+.shadow-glow{ box-shadow:0 0 20px var(--shadow-glow); }
 
 /* Hamburger / Mobile menu */
-.hamburger-line{ width:18px; height:2px; background:rgba(255,255,255,.8); margin:2px 0; display:block }
-.mobile-menu{ background:rgba(0,0,0,.9); border-top:1px solid rgba(255,255,255,.12); padding:.75rem 1rem; }
-.mobile-menu a{ display:block; padding:.5rem 0; border-bottom:1px solid rgba(255,255,255,.06); }
-.mobile-menu a:last-child{ border-bottom:0; }
+.hamburger-line{ width:18px; height:2px; background:rgba(255,255,255,.8); margin:2px 0; display:block; transition:background .2s ease; }
+body.theme-light .hamburger-line{ background:rgba(40,26,80,.85); }
+.mobile-menu{ background:var(--mobile-menu-bg); border-top:1px solid var(--mobile-menu-border); padding:.75rem 1rem; color:var(--text-primary); }
+.mobile-menu a{ display:block; padding:.5rem 0; border-bottom:1px solid var(--border-subtle); color:var(--text-primary); }
+.mobile-menu a:last-of-type{ border-bottom:0; }
+.mobile-menu button{ width:100%; color:var(--text-primary); border:1px solid var(--border-soft); background:var(--surface); border-radius:.5rem; padding:.6rem .75rem; margin-top:.5rem; }
+
+/* Footer */
+footer{ background:var(--footer-bg); color:var(--footer-text); }
+footer a{ color:inherit; }
+footer a:hover{ color:var(--footer-link-hover); }
+
+/* Utility overrides for Tailwind classes */
+.text-white{ color:var(--text-primary) !important; }
+.text-white\/80{ color:var(--text-secondary) !important; }
+.text-white\/70{ color:var(--text-secondary) !important; }
+.text-white\/60{ color:var(--text-muted) !important; }
+.text-purple-200{ color:var(--accent-soft) !important; }
+.text-purple-300{ color:var(--accent-strong) !important; }
+.hover\:text-purple-300:hover{ color:var(--accent-strong) !important; }
+.border-white\/10{ border-color:var(--border-subtle) !important; }
+.border-white\/15{ border-color:var(--border-soft) !important; }
+.border-white\/20{ border-color:var(--border-strong) !important; }
+.bg-white\/5{ background-color:var(--surface) !important; }
+.from-white\/5{ --tw-gradient-from: var(--surface) !important; --tw-gradient-stops: var(--surface), rgba(255,255,255,0); }
+.via-black\/30{ --tw-gradient-stops: rgba(0,0,0,0), rgba(0,0,0,.3), rgba(0,0,0,.9); }
+body.theme-light .via-black\/30{ --tw-gradient-stops: rgba(246,243,255,0), rgba(247,243,255,.7), rgba(246,243,255,1); }
+body.theme-light .to-black{ --tw-gradient-to: rgba(247,243,255,1) !important; }
 
 /* Responsive Cards */
 @media (max-width: 640px){
-  .card3d{ width:88vw; }
-  .card3d-img{ height:160px; }
+  #gamesTrack,
+  #pluginsTrack{
+    display:flex;
+    flex-direction:column;
+    align-items:stretch;
+    overflow:visible;
+    scroll-snap-type:unset;
+  }
+
+  .card3d{ width:100%; }
+
+  /* Buttons full width on mobile */
+  .btn-primary,
+  .btn-outline{ width:100%; }
+
+  .carousel-controls{ display:none; }
 }
 
-/* Buttons full width on mobile */
-@media (max-width: 640px){
-  .btn-primary, .btn-outline{ width:100%; text-align:center }
+@media (min-width: 1024px){
+  #gamesTrack, #pluginsTrack{ justify-content:center; }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .card3d{ transition: background .2s ease; }
 }


### PR DESCRIPTION
## Summary
- invert the light theme sticky navbar controls to use accent backgrounds with white text
- add theme-aware hero overlay and tagline colors so the light mode hero reads in black and white gradients

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d16e0ba4832f9850f854c4cb5e0d