### PR TITLE
Add Chinese and Japanese localization support

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,18 +60,26 @@
 
       <!-- Desktop nav -->
       <nav class="hidden md:flex gap-4 lg:gap-6 text-sm font-medium" aria-label="Primary">
-        <a class="hover:text-purple-300" href="#games">Games</a>
-        <a class="hover:text-purple-300" href="#plugins">Plugins</a>
-        <a class="hover:text-purple-300" href="#news">News</a>
-        <a class="hover:text-purple-300" href="#careers">Careers</a>
-        <a class="hover:text-purple-300" href="#about">About</a>
-        <a class="hover:text-purple-300" href="#team">Team</a>
-        <a class="hover:text-purple-300" href="#contact">Contact</a>
+        <a class="hover:text-purple-300" href="#games" data-i18n="nav.games">Games</a>
+        <a class="hover:text-purple-300" href="#plugins" data-i18n="nav.plugins">Plugins</a>
+        <a class="hover:text-purple-300" href="#news" data-i18n="nav.news">News</a>
+        <a class="hover:text-purple-300" href="#careers" data-i18n="nav.careers">Careers</a>
+        <a class="hover:text-purple-300" href="#about" data-i18n="nav.about">About</a>
+        <a class="hover:text-purple-300" href="#team" data-i18n="nav.team">Team</a>
+        <a class="hover:text-purple-300" href="#contact" data-i18n="nav.contact">Contact</a>
       </nav>
 
       <!-- Mobile controls -->
       <div class="flex items-center gap-3">
-        <button id="muteBtn" class="hidden md:inline-block px-3 py-1.5 rounded-md text-xs border border-white/15 hover:border-purple-400/50 hover:text-purple-300" aria-label="Toggle SFX">Unmute SFX</button>
+        <label class="sr-only" for="languageSelect" data-i18n="nav.languageLabel">Select language</label>
+        <select id="languageSelect" class="hidden md:inline-block px-2 py-1 text-xs rounded-md border border-white/20 bg-black/40 hover:border-purple-400/50 focus:outline-none focus:border-purpleNeo" data-i18n-aria-label="nav.languageLabel">
+          <option value="en">EN</option>
+          <option value="pt">PT</option>
+          <option value="es">ES</option>
+          <option value="zh">ZH</option>
+          <option value="ja">JA</option>
+        </select>
+        <button id="muteBtn" class="hidden md:inline-block px-3 py-1.5 rounded-md text-xs border border-white/15 hover:border-purple-400/50 hover:text-purple-300" aria-label="Toggle SFX" data-i18n="nav.unmute">Unmute SFX</button>
         <button id="hamburger" class="md:hidden h-9 w-9 grid place-items-center border border-white/20 rounded" aria-label="Open menu" aria-expanded="false">
           <span class="hamburger-line"></span>
           <span class="hamburger-line"></span>
@@ -82,14 +90,24 @@
 
     <!-- Mobile menu -->
     <div id="mobileMenu" class="mobile-menu hidden md:hidden" aria-label="Mobile menu">
-      <a href="#games">Games</a>
-      <a href="#plugins">Plugins</a>
-      <a href="#news">News</a>
-      <a href="#careers">Careers</a>
-      <a href="#about">About</a>
-      <a href="#team">Team</a>
-      <a href="#contact">Contact</a>
-      <button id="muteBtnMobile" class="mt-2 px-3 py-1.5 rounded-md text-xs border border-white/15">Unmute SFX</button>
+      <div class="flex items-center justify-between">
+        <span class="text-xs font-semibold" data-i18n="nav.menuTitle">Menu</span>
+        <select id="languageSelectMobile" class="px-2 py-1 text-xs rounded-md border border-white/20 bg-black/40 focus:outline-none focus:border-purpleNeo" data-i18n-aria-label="nav.languageLabel">
+          <option value="en">EN</option>
+          <option value="pt">PT</option>
+          <option value="es">ES</option>
+          <option value="zh">ZH</option>
+          <option value="ja">JA</option>
+        </select>
+      </div>
+      <a href="#games" data-i18n="nav.games">Games</a>
+      <a href="#plugins" data-i18n="nav.plugins">Plugins</a>
+      <a href="#news" data-i18n="nav.news">News</a>
+      <a href="#careers" data-i18n="nav.careers">Careers</a>
+      <a href="#about" data-i18n="nav.about">About</a>
+      <a href="#team" data-i18n="nav.team">Team</a>
+      <a href="#contact" data-i18n="nav.contact">Contact</a>
+      <button id="muteBtnMobile" class="mt-2 px-3 py-1.5 rounded-md text-xs border border-white/15" data-i18n="nav.unmute">Unmute SFX</button>
     </div>
   </header>
 
@@ -98,15 +116,15 @@
     <canvas id="particles" class="absolute inset-0 w-full h-full"></canvas>
     <div class="absolute inset-0 bg-gradient-to-b from-transparent via-black/30 to-black"></div>
     <div class="relative z-10 text-center px-4 sm:px-6" id="heroContent">
-      <h1 class="text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight">
+      <h1 class="text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight" data-i18n="hero.title">
         Creating Worlds. <span class="text-purpleNeo">Inspiring Players.</span>
       </h1>
-      <p class="mt-4 text-sm sm:text-base md:text-lg text-white/80 max-w-2xl mx-auto">
+      <p class="mt-4 text-sm sm:text-base md:text-lg text-white/80 max-w-2xl mx-auto" data-i18n="hero.subtitle">
         Brazilian game studio crafting immersive experiences with technology, creativity and passion.
       </p>
       <div class="mt-8 flex flex-wrap justify-center gap-3">
-        <a href="#games" class="btn-primary shadow-lg">Explore Games</a>
-        <a href="#plugins" class="btn-outline">See Plugins</a>
+        <a href="#games" class="btn-primary shadow-lg" data-i18n="hero.ctaGames">Explore Games</a>
+        <a href="#plugins" class="btn-outline" data-i18n="hero.ctaPlugins">See Plugins</a>
       </div>
     </div>
   </section>
@@ -114,23 +132,23 @@
   <!-- Games -->
   <section id="games" class="py-20 sm:py-24 bg-black">
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6">Our Games</h2>
-      <p class="text-white/60 mb-6 max-w-3xl">Worlds built with heart and cutting-edge tech. Drag to explore.</p>
+      <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6" data-i18n="games.title">Our Games</h2>
+      <p class="text-white/60 mb-6 max-w-3xl" data-i18n="games.subtitle">Worlds built with heart and cutting-edge tech. Drag to explore.</p>
       <div class="relative">
         <div id="gamesTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
           <div class="card3d" data-card>
             <div class="card3d-img"><img src="img/frontline.png" alt="Frontline on Steam" /></div>
             <div class="p-5">
               <h3 class="card3d-title">Frontline</h3>
-              <p class="card3d-desc">An immersive tactical shooter combining realism, intensity, and storytelling — available now on Steam.</p>
-              <a href="https://store.steampowered.com/app/1772220/Frontline_New_Revolution/" target="_blank" rel="noopener" class="card3d-link">Learn More →</a>
+              <p class="card3d-desc" data-i18n="games.frontline">An immersive tactical shooter combining realism, intensity, and storytelling — available now on Steam.</p>
+              <a href="https://store.steampowered.com/app/1772220/Frontline_New_Revolution/" target="_blank" rel="noopener" class="card3d-link" data-i18n="shared.learnMore">Learn More →</a>
             </div>
           </div>
           <div class="card3d" data-card>
             <div class="card3d-img"><img src="img/rampagerush.jpg" alt="Rampage Rush concept art" /></div>
             <div class="p-5">
               <h3 class="card3d-title">Rampage Rush</h3>
-              <p class="card3d-desc">A musical brawler with a chaotic rhythm that offers pure adrenaline, destruction and chaos in multiplayer mode.</p>
+              <p class="card3d-desc" data-i18n="games.rampage">A musical brawler with a chaotic rhythm that offers pure adrenaline, destruction and chaos in multiplayer mode.</p>
               <!-- <a href="#" class="card3d-link">Learn More →</a> -->
             </div>
           </div>
@@ -138,7 +156,7 @@
             <div class="card3d-img"><img src="img/dissociation.jpg" alt="Bananapocalypse artwork" /></div>
             <div class="p-5">
               <h3 class="card3d-title">Dissociation</h3>
-              <p class="card3d-desc">A psychological horror where an AI manipulates your every move — no weapons, no escape, only survival. Do you know what’s real?</p>
+              <p class="card3d-desc" data-i18n="games.dissociation">A psychological horror where an AI manipulates your every move — no weapons, no escape, only survival. Do you know what’s real?</p>
               <!-- <a href="#" class="card3d-link">Learn More →</a> -->
             </div>
           </div>
@@ -146,14 +164,14 @@
             <div class="card3d-img"><img src="img/banapocalypse.png" alt="Bananapocalypse artwork" /></div>
             <div class="p-5">
               <h3 class="card3d-title">Bananapocalypse</h3>
-              <p class="card3d-desc">A humorous survival adventure where mutant bananas rule the world — can you fight the fruit uprising?</p>
+              <p class="card3d-desc" data-i18n="games.banana">A humorous survival adventure where mutant bananas rule the world — can you fight the fruit uprising?</p>
               <!-- <a href="#" class="card3d-link">Learn More →</a> -->
             </div>
           </div>
         </div>
         <div class="carousel-controls">
-          <button id="gamesPrev" aria-label="Previous">‹</button>
-          <button id="gamesNext" aria-label="Next">›</button>
+          <button id="gamesPrev" aria-label="Previous" data-i18n-aria-label="carousel.prev">‹</button>
+          <button id="gamesNext" aria-label="Next" data-i18n-aria-label="carousel.next">›</button>
         </div>
       </div>
     </div>
@@ -163,8 +181,8 @@
   <section id="plugins" class="relative py-20 sm:py-24 bg-[#0b0114]">
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
       <div class="flex items-end justify-between mb-6">
-        <h2 class="text-2xl sm:text-3xl font-bold">Our Plugins</h2>
-        <span class="text-xs text-purple-300/70">Fab marketplace listings</span>
+        <h2 class="text-2xl sm:text-3xl font-bold" data-i18n="plugins.title">Our Plugins</h2>
+        <span class="text-xs text-purple-300/70" data-i18n="plugins.subtitle">Fab marketplace listings</span>
       </div>
       <div class="relative">
         <div id="pluginsTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
@@ -172,22 +190,22 @@
             <div class="card3d-img"><img src="img/WorldProceduralGeneratorPlugin.jpg" alt="World Procedural Generator Plugin cover" /></div>
             <div class="p-5">
               <h3 class="card3d-title">World Procedural Generator Plugin</h3>
-              <p class="card3d-desc">Create vast and dynamic open worlds in Unreal Engine with procedural terrain, biomes, and asset placement.</p>
-              <a href="https://www.fab.com/pt-br/listings/5b18f63c-894d-40b8-846a-bf4670ee9eeb" target="_blank" rel="noopener" class="card3d-link">View Plugin →</a>
+              <p class="card3d-desc" data-i18n="plugins.world">Create vast and dynamic open worlds in Unreal Engine with procedural terrain, biomes, and asset placement.</p>
+              <a href="https://www.fab.com/pt-br/listings/5b18f63c-894d-40b8-846a-bf4670ee9eeb" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
             </div>
           </div>
           <div class="card3d" data-card>
             <div class="card3d-img"><img src="img/ReplicatedExplosionPlugin.jpg" alt="Replicated Explosion Plugin cover" /></div>
             <div class="p-5">
               <h3 class="card3d-title">Replicated Explosion Plugin</h3>
-              <p class="card3d-desc">Add fully replicated, network-ready explosions with customizable effects and optimized physics.</p>
-              <a href="https://www.fab.com/pt-br/listings/13134d3a-256f-44bc-9052-3dd69e87932d" target="_blank" rel="noopener" class="card3d-link">View Plugin →</a>
+              <p class="card3d-desc" data-i18n="plugins.explosion">Add fully replicated, network-ready explosions with customizable effects and optimized physics.</p>
+              <a href="https://www.fab.com/pt-br/listings/13134d3a-256f-44bc-9052-3dd69e87932d" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
             </div>
           </div>
         </div>
         <div class="carousel-controls">
-          <button id="pluginsPrev" aria-label="Previous">‹</button>
-          <button id="pluginsNext" aria-label="Next">›</button>
+          <button id="pluginsPrev" aria-label="Previous" data-i18n-aria-label="carousel.prev">‹</button>
+          <button id="pluginsNext" aria-label="Next" data-i18n-aria-label="carousel.next">›</button>
         </div>
       </div>
     </div>
@@ -196,17 +214,17 @@
   <!-- News -->
   <section id="news" class="py-20 sm:py-24 bg-black">
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-10">Latest News</h2>
+      <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-10" data-i18n="news.title">Latest News</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <article class="news-card">
-          <p class="news-date">September 2025</p>
-          <h3 class="news-title">Frontline Launches on Steam</h3>
-          <p class="news-summary">After nearly six years in development, our debut title has officially launched — explore the revolution now.</p>
+          <p class="news-date" data-i18n="news.frontline.date">September 2025</p>
+          <h3 class="news-title" data-i18n="news.frontline.title">Frontline Launches on Steam</h3>
+          <p class="news-summary" data-i18n="news.frontline.copy">After nearly six years in development, our debut title has officially launched — explore the revolution now.</p>
         </article>
         <article class="news-card">
-          <p class="news-date">July 2025</p>
-          <h3 class="news-title">Neo Soft Expands Team</h3>
-          <p class="news-summary">We’re growing! Neo Soft welcomes new talent as we take on the next chapter of our journey.</p>
+          <p class="news-date" data-i18n="news.team.date">July 2025</p>
+          <h3 class="news-title" data-i18n="news.team.title">Neo Soft Expands Team</h3>
+          <p class="news-summary" data-i18n="news.team.copy">We’re growing! Neo Soft welcomes new talent as we take on the next chapter of our journey.</p>
         </article>
       </div>
     </div>
@@ -216,20 +234,20 @@
   <section id="careers" class="py-20 sm:py-24 bg-gradient-to-b from-[#0b0114] to-black">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 grid md:grid-cols-5 gap-8 md:gap-10 items-center">
       <div class="md:col-span-3">
-        <h2 class="text-2xl sm:text-3xl font-bold mb-3">Careers</h2>
-        <p class="text-white/70">We’re hiring! Developers, artists and designers passionate about building next-gen experiences. Help us shape the future of interactive entertainment.</p>
+        <h2 class="text-2xl sm:text-3xl font-bold mb-3" data-i18n="careers.title">Careers</h2>
+        <p class="text-white/70" data-i18n="careers.copy">We’re hiring! Developers, artists and designers passionate about building next-gen experiences. Help us shape the future of interactive entertainment.</p>
         <div class="mt-6 flex flex-wrap gap-3">
-          <a href="mailto:contact@neeosoft.com.br" class="btn-primary">Apply Now</a>
-          <a href="#team" class="btn-outline">Meet the Team</a>
+          <a href="mailto:contact@neeosoft.com.br" class="btn-primary" data-i18n="careers.apply">Apply Now</a>
+          <a href="#team" class="btn-outline" data-i18n="careers.team">Meet the Team</a>
         </div>
       </div>
       <div class="md:col-span-2 rounded-xl border border-white/10 p-6 bg-white/5">
-        <h3 class="font-semibold mb-2 text-purple-200">Open Roles</h3>
+        <h3 class="font-semibold mb-2 text-purple-200" data-i18n="careers.open">Open Roles</h3>
         <ul class="space-y-2 text-sm text-white/80">
-          <li>• Gameplay Programmer (Unreal)</li>
-          <li>• Technical Artist</li>
-          <li>• 3D Environment Artist</li>
-          <li>• Narrative Designer</li>
+          <li data-i18n="careers.roles.gameplay">• Gameplay Programmer (Unreal)</li>
+          <li data-i18n="careers.roles.technical">• Technical Artist</li>
+          <li data-i18n="careers.roles.environment">• 3D Environment Artist</li>
+          <li data-i18n="careers.roles.narrative">• Narrative Designer</li>
         </ul>
       </div>
     </div>
@@ -239,13 +257,13 @@
   <section id="about" class="py-20 sm:py-24 bg-black">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 grid lg:grid-cols-2 gap-8 md:gap-10 items-center">
       <div>
-        <h2 class="text-2xl sm:text-3xl font-bold mb-3">About Neo Soft</h2>
-        <p class="text-white/80 mb-3">Founded in 2020 by <strong>Victor</strong>, Neo Soft is a Brazilian studio creating games and tools that inspire and empower creators.</p>
-        <p class="text-white/70">Our debut project, <em>Frontline</em>, represents our commitment to innovation and storytelling. We’ve been building for almost six years with a dedicated team — all driven by the love of games.</p>
+        <h2 class="text-2xl sm:text-3xl font-bold mb-3" data-i18n="about.title">About Neo Soft</h2>
+        <p class="text-white/80 mb-3" data-i18n="about.first">Founded in 2020 by <strong>Victor</strong>, Neo Soft is a Brazilian studio creating games and tools that inspire and empower creators.</p>
+        <p class="text-white/70" data-i18n="about.second">Our debut project, <em>Frontline</em>, represents our commitment to innovation and storytelling. We’ve been building for almost six years with a dedicated team — all driven by the love of games.</p>
       </div>
       <div class="rounded-xl border border-white/10 p-8 bg-gradient-to-br from-white/5 to-transparent">
-        <h3 class="text-xl font-semibold mb-2 text-purple-200">Our Mission</h3>
-        <p class="text-white/80">To strengthen the Brazilian gaming scene by delivering world-class projects that showcase creativity and excellence.</p>
+        <h3 class="text-xl font-semibold mb-2 text-purple-200" data-i18n="about.missionTitle">Our Mission</h3>
+        <p class="text-white/80" data-i18n="about.missionCopy">To strengthen the Brazilian gaming scene by delivering world-class projects that showcase creativity and excellence.</p>
       </div>
     </div>
   </section>
@@ -253,7 +271,7 @@
   <!-- Team -->
   <section id="team" class="py-20 sm:py-24 bg-[#0b0114]">
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <h2 class="text-2xl sm:text-3xl font-bold text-purple-200 mb-8 sm:mb-10">Our Team</h2>
+      <h2 class="text-2xl sm:text-3xl font-bold text-purple-200 mb-8 sm:mb-10" data-i18n="team.title">Our Team</h2>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         <div class="team-card"><div class="team-avatar"><img src="img/victor.jpg" alt="Victor Henrique" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Victor Henrique</h3><p class="team-role">Founder & Senior Developer</p></div>
         <div class="team-card"><div class="team-avatar"><img src="img/hiury.jpg" alt="Hiury Francisco" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Hiury Francisco</h3><p class="team-role">Video Editor & Production Lead</p></div>
@@ -266,37 +284,37 @@
   <!-- Contact -->
   <section id="contact" class="py-20 sm:py-24 bg-black">
     <div class="max-w-5xl mx-auto px-4 sm:px-6">
-      <h2 class="text-2xl sm:text-3xl font-bold mb-6">Contact Us</h2>
-      <p class="text-white/70 mb-8 max-w-2xl">Want to collaborate, ask questions, or share feedback? Get in touch — we’d love to hear from you.</p>
+      <h2 class="text-2xl sm:text-3xl font-bold mb-6" data-i18n="contact.title">Contact Us</h2>
+      <p class="text-white/70 mb-8 max-w-2xl" data-i18n="contact.copy">Want to collaborate, ask questions, or share feedback? Get in touch — we’d love to hear from you.</p>
       <form id="contactForm" class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <input name="from_name" class="input" placeholder="Your name" required />
-        <input name="from_mail" type="email" class="input" placeholder="Email" required />
-        <textarea name="message" class="textarea sm:col-span-2" placeholder="Your message" required></textarea>
+        <input name="from_name" class="input" placeholder="Your name" required data-i18n-placeholder="contact.name" />
+        <input name="from_mail" type="email" class="input" placeholder="Email" required data-i18n-placeholder="contact.email" />
+        <textarea name="message" class="textarea sm:col-span-2" placeholder="Your message" required data-i18n-placeholder="contact.message"></textarea>
         <div class="sm:col-span-2 flex items-center justify-between">
-          <button type="submit" id="sendBtn" class="btn-primary">Send Message</button>
+          <button type="submit" id="sendBtn" class="btn-primary" data-i18n="contact.send">Send Message</button>
         </div>
       </form>
       <div id="formFeedback" class="hidden mt-6 inline-flex items-center gap-2 text-green-400" role="status" aria-live="polite">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>
-        Message sent! We’ll get back to you soon.
+        <span id="formFeedbackText" data-i18n="contact.success">Message sent! We’ll get back to you soon.</span>
       </div>
     </div>
   </section>
 
   <!-- Back to top -->
-  <button id="backToTop" class="hidden fixed bottom-6 right-6 z-40 h-11 w-11 rounded-full bg-gradient-to-br from-purpleNeo to-fuchsiaNeo shadow-lg hover:scale-105 transition" aria-label="Back to top">↑</button>
+  <button id="backToTop" class="hidden fixed bottom-6 right-6 z-40 h-11 w-11 rounded-full bg-gradient-to-br from-purpleNeo to-fuchsiaNeo shadow-lg hover:scale-105 transition" aria-label="Back to top" data-i18n-aria-label="shared.backToTop">↑</button>
 
   <!-- Footer -->
   <footer class="border-t border-white/10 bg-black text-white/60 text-sm">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex flex-col sm:flex-row justify-between items-center gap-3">
-      <p>© <span id="year"></span> Neo Soft. Founded by Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a></p>
+      <p data-i18n="footer.copy">© <span id="year"></span> Neo Soft. Founded by Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a></p>
       <div class="flex flex-wrap gap-4">
-        <a class="hover:text-purple-300" href="#games">Games</a>
-        <a class="hover:text-purple-300" href="#plugins">Plugins</a>
-        <a class="hover:text-purple-300" href="#news">News</a>
-        <a class="hover:text-purple-300" href="#careers">Careers</a>
-        <a class="hover:text-purple-300" href="#team">Team</a>
-        <a class="hover:text-purple-300" href="#contact">Contact</a>
+        <a class="hover:text-purple-300" href="#games" data-i18n="nav.games">Games</a>
+        <a class="hover:text-purple-300" href="#plugins" data-i18n="nav.plugins">Plugins</a>
+        <a class="hover:text-purple-300" href="#news" data-i18n="nav.news">News</a>
+        <a class="hover:text-purple-300" href="#careers" data-i18n="nav.careers">Careers</a>
+        <a class="hover:text-purple-300" href="#team" data-i18n="nav.team">Team</a>
+        <a class="hover:text-purple-300" href="#contact" data-i18n="nav.contact">Contact</a>
       </div>
     </div>
   </footer>

--- a/js/script.js
+++ b/js/script.js
@@ -14,18 +14,397 @@
   const muteBtnMobile = $('#muteBtnMobile');
   const mobileMenu = $('#mobileMenu');
   const hamburger = $('#hamburger');
+  const languageSelect = $('#languageSelect');
+  const languageSelectMobile = $('#languageSelectMobile');
   const contactForm = $('#contactForm');
   const formFeedback = $('#formFeedback');
-  const yearSpan = $('#year');
+  const sendBtn = $('#sendBtn');
 
-  // Year
-  if (yearSpan) yearSpan.textContent = new Date().getFullYear();
+  const translations = {
+    en: {
+      'nav.games': 'Games',
+      'nav.plugins': 'Plugins',
+      'nav.news': 'News',
+      'nav.careers': 'Careers',
+      'nav.about': 'About',
+      'nav.team': 'Team',
+      'nav.contact': 'Contact',
+      'nav.unmute': 'Unmute SFX',
+      'nav.mute': 'Mute SFX',
+      'nav.languageLabel': 'Select language',
+      'nav.menuTitle': 'Menu',
+      'hero.title': 'Creating Worlds. <span class="text-purpleNeo">Inspiring Players.</span>',
+      'hero.subtitle': 'Brazilian game studio crafting immersive experiences with technology, creativity and passion.',
+      'hero.ctaGames': 'Explore Games',
+      'hero.ctaPlugins': 'See Plugins',
+      'games.title': 'Our Games',
+      'games.subtitle': 'Worlds built with heart and cutting-edge tech. Drag to explore.',
+      'games.frontline': 'An immersive tactical shooter combining realism, intensity, and storytelling — available now on Steam.',
+      'games.rampage': 'A musical brawler with a chaotic rhythm that offers pure adrenaline, destruction and chaos in multiplayer mode.',
+      'games.dissociation': 'A psychological horror where an AI manipulates your every move — no weapons, no escape, only survival. Do you know what’s real?',
+      'games.banana': 'A humorous survival adventure where mutant bananas rule the world — can you fight the fruit uprising?',
+      'shared.learnMore': 'Learn More →',
+      'shared.backToTop': 'Back to top',
+      'carousel.prev': 'Previous',
+      'carousel.next': 'Next',
+      'plugins.title': 'Our Plugins',
+      'plugins.subtitle': 'Fab marketplace listings',
+      'plugins.world': 'Create vast and dynamic open worlds in Unreal Engine with procedural terrain, biomes, and asset placement.',
+      'plugins.explosion': 'Add fully replicated, network-ready explosions with customizable effects and optimized physics.',
+      'plugins.view': 'View Plugin →',
+      'news.title': 'Latest News',
+      'news.frontline.date': 'September 2025',
+      'news.frontline.title': 'Frontline Launches on Steam',
+      'news.frontline.copy': 'After nearly six years in development, our debut title has officially launched — explore the revolution now.',
+      'news.team.date': 'July 2025',
+      'news.team.title': 'Neo Soft Expands Team',
+      'news.team.copy': 'We’re growing! Neo Soft welcomes new talent as we take on the next chapter of our journey.',
+      'careers.title': 'Careers',
+      'careers.copy': 'We’re hiring! Developers, artists and designers passionate about building next-gen experiences. Help us shape the future of interactive entertainment.',
+      'careers.apply': 'Apply Now',
+      'careers.team': 'Meet the Team',
+      'careers.open': 'Open Roles',
+      'careers.roles.gameplay': '• Gameplay Programmer (Unreal)',
+      'careers.roles.technical': '• Technical Artist',
+      'careers.roles.environment': '• 3D Environment Artist',
+      'careers.roles.narrative': '• Narrative Designer',
+      'about.title': 'About Neo Soft',
+      'about.first': 'Founded in 2020 by <strong>Victor</strong>, Neo Soft is a Brazilian studio creating games and tools that inspire and empower creators.',
+      'about.second': 'Our debut project, <em>Frontline</em>, represents our commitment to innovation and storytelling. We’ve been building for almost six years with a dedicated team — all driven by the love of games.',
+      'about.missionTitle': 'Our Mission',
+      'about.missionCopy': 'To strengthen the Brazilian gaming scene by delivering world-class projects that showcase creativity and excellence.',
+      'team.title': 'Our Team',
+      'contact.title': 'Contact Us',
+      'contact.copy': 'Want to collaborate, ask questions, or share feedback? Get in touch — we’d love to hear from you.',
+      'contact.name': 'Your name',
+      'contact.email': 'Email',
+      'contact.message': 'Your message',
+      'contact.send': 'Send Message',
+      'contact.sending': 'Sending...',
+      'contact.success': 'Message sent! We’ll get back to you soon.',
+      'contact.error': 'Something went wrong. Please try again later.',
+      'footer.copy': '© <span id="year"></span> Neo Soft. Founded by Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
+    },
+    pt: {
+      'nav.games': 'Jogos',
+      'nav.plugins': 'Plugins',
+      'nav.news': 'Notícias',
+      'nav.careers': 'Carreiras',
+      'nav.about': 'Sobre',
+      'nav.team': 'Equipe',
+      'nav.contact': 'Contato',
+      'nav.unmute': 'Ativar efeitos',
+      'nav.mute': 'Desativar efeitos',
+      'nav.languageLabel': 'Selecionar idioma',
+      'nav.menuTitle': 'Menu',
+      'hero.title': 'Criando Mundos. <span class="text-purpleNeo">Inspirando Jogadores.</span>',
+      'hero.subtitle': 'Estúdio brasileiro de jogos criando experiências imersivas com tecnologia, criatividade e paixão.',
+      'hero.ctaGames': 'Explorar jogos',
+      'hero.ctaPlugins': 'Ver plugins',
+      'games.title': 'Nossos Jogos',
+      'games.subtitle': 'Mundos construídos com coração e tecnologia de ponta. Arraste para explorar.',
+      'games.frontline': 'Um shooter tático imersivo que combina realismo, intensidade e narrativa — disponível agora na Steam.',
+      'games.rampage': 'Um brawler musical de ritmo caótico que entrega adrenalina, destruição e caos no modo multiplayer.',
+      'games.dissociation': 'Um terror psicológico em que uma IA manipula cada movimento seu — sem armas, sem escape, só sobrevivência. Você sabe o que é real?',
+      'games.banana': 'Uma aventura de sobrevivência bem-humorada em que bananas mutantes dominam o mundo — você consegue conter a revolta das frutas?',
+      'shared.learnMore': 'Saiba mais →',
+      'shared.backToTop': 'Voltar ao topo',
+      'carousel.prev': 'Anterior',
+      'carousel.next': 'Próximo',
+      'plugins.title': 'Nossos Plugins',
+      'plugins.subtitle': 'Listagens na Fab',
+      'plugins.world': 'Crie mundos abertos vastos e dinâmicos no Unreal Engine com terreno procedural, biomas e posicionamento de assets.',
+      'plugins.explosion': 'Adicione explosões totalmente replicadas, prontas para rede, com efeitos personalizáveis e física otimizada.',
+      'plugins.view': 'Ver plugin →',
+      'news.title': 'Últimas Notícias',
+      'news.frontline.date': 'Setembro de 2025',
+      'news.frontline.title': 'Frontline é lançado na Steam',
+      'news.frontline.copy': 'Após quase seis anos de desenvolvimento, nosso título de estreia foi lançado oficialmente — explore a revolução agora.',
+      'news.team.date': 'Julho de 2025',
+      'news.team.title': 'Neo Soft expande o time',
+      'news.team.copy': 'Estamos crescendo! A Neo Soft recebe novos talentos enquanto avançamos para o próximo capítulo da nossa jornada.',
+      'careers.title': 'Carreiras',
+      'careers.copy': 'Estamos contratando! Desenvolvedores, artistas e designers apaixonados por criar experiências de nova geração. Ajude-nos a moldar o futuro do entretenimento interativo.',
+      'careers.apply': 'Inscreva-se',
+      'careers.team': 'Conheça a equipe',
+      'careers.open': 'Vagas abertas',
+      'careers.roles.gameplay': '• Programador(a) de Gameplay (Unreal)',
+      'careers.roles.technical': '• Artista Técnico(a)',
+      'careers.roles.environment': '• Artista 3D de Cenários',
+      'careers.roles.narrative': '• Designer Narrativo',
+      'about.title': 'Sobre a Neo Soft',
+      'about.first': 'Fundada em 2020 por <strong>Victor</strong>, a Neo Soft é um estúdio brasileiro que cria jogos e ferramentas para inspirar e potencializar criadores.',
+      'about.second': 'Nosso projeto de estreia, <em>Frontline</em>, representa nosso compromisso com inovação e narrativa. Estamos construindo há quase seis anos com uma equipe dedicada — movida pelo amor aos jogos.',
+      'about.missionTitle': 'Nossa missão',
+      'about.missionCopy': 'Fortalecer a cena brasileira de games entregando projetos de classe mundial que exibem criatividade e excelência.',
+      'team.title': 'Nossa equipe',
+      'contact.title': 'Fale conosco',
+      'contact.copy': 'Quer colaborar, tirar dúvidas ou compartilhar feedback? Entre em contato — vamos adorar conversar com você.',
+      'contact.name': 'Seu nome',
+      'contact.email': 'Email',
+      'contact.message': 'Sua mensagem',
+      'contact.send': 'Enviar mensagem',
+      'contact.sending': 'Enviando...',
+      'contact.success': 'Mensagem enviada! Responderemos em breve.',
+      'contact.error': 'Algo deu errado. Tente novamente mais tarde.',
+      'footer.copy': '© <span id="year"></span> Neo Soft. Fundada por Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
+    },
+    es: {
+      'nav.games': 'Juegos',
+      'nav.plugins': 'Plugins',
+      'nav.news': 'Noticias',
+      'nav.careers': 'Carreras',
+      'nav.about': 'Acerca de',
+      'nav.team': 'Equipo',
+      'nav.contact': 'Contacto',
+      'nav.unmute': 'Activar efectos',
+      'nav.mute': 'Silenciar efectos',
+      'nav.languageLabel': 'Seleccionar idioma',
+      'nav.menuTitle': 'Menú',
+      'hero.title': 'Creando Mundos. <span class="text-purpleNeo">Inspirando Jugadores.</span>',
+      'hero.subtitle': 'Estudio brasileño de videojuegos que crea experiencias inmersivas con tecnología, creatividad y pasión.',
+      'hero.ctaGames': 'Explorar juegos',
+      'hero.ctaPlugins': 'Ver plugins',
+      'games.title': 'Nuestros Juegos',
+      'games.subtitle': 'Mundos construidos con corazón y tecnología de punta. Arrastra para explorar.',
+      'games.frontline': 'Un shooter táctico inmersivo que combina realismo, intensidad y narrativa — disponible ahora en Steam.',
+      'games.rampage': 'Un brawler musical con un ritmo caótico que ofrece adrenalina pura, destrucción y caos en modo multijugador.',
+      'games.dissociation': 'Un terror psicológico donde una IA manipula cada uno de tus movimientos — sin armas, sin escape, solo supervivencia. ¿Sabes qué es real?',
+      'games.banana': 'Una aventura de supervivencia humorística donde bananas mutantes dominan el mundo — ¿podrás detener la rebelión frutal?',
+      'shared.learnMore': 'Saber más →',
+      'shared.backToTop': 'Volver arriba',
+      'carousel.prev': 'Anterior',
+      'carousel.next': 'Siguiente',
+      'plugins.title': 'Nuestros Plugins',
+      'plugins.subtitle': 'Listados en Fab',
+      'plugins.world': 'Crea mundos abiertos vastos y dinámicos en Unreal Engine con terreno procedural, biomas y colocación de assets.',
+      'plugins.explosion': 'Añade explosiones totalmente replicadas, listas para red, con efectos personalizables y física optimizada.',
+      'plugins.view': 'Ver plugin →',
+      'news.title': 'Últimas Noticias',
+      'news.frontline.date': 'Septiembre de 2025',
+      'news.frontline.title': 'Frontline se lanza en Steam',
+      'news.frontline.copy': 'Tras casi seis años de desarrollo, nuestro título debut se ha lanzado oficialmente — explora la revolución ahora.',
+      'news.team.date': 'Julio de 2025',
+      'news.team.title': 'Neo Soft amplía el equipo',
+      'news.team.copy': '¡Estamos creciendo! Neo Soft recibe nuevo talento mientras abordamos el próximo capítulo de nuestro viaje.',
+      'careers.title': 'Carreras',
+      'careers.copy': '¡Estamos contratando! Desarrolladores, artistas y diseñadores apasionados por crear experiencias de nueva generación. Ayúdanos a dar forma al futuro del entretenimiento interactivo.',
+      'careers.apply': 'Postular ahora',
+      'careers.team': 'Conoce al equipo',
+      'careers.open': 'Vacantes abiertas',
+      'careers.roles.gameplay': '• Programador(a) de Gameplay (Unreal)',
+      'careers.roles.technical': '• Artista Técnico(a)',
+      'careers.roles.environment': '• Artista 3D de Entornos',
+      'careers.roles.narrative': '• Diseñador(a) Narrativo',
+      'about.title': 'Acerca de Neo Soft',
+      'about.first': 'Fundado en 2020 por <strong>Victor</strong>, Neo Soft es un estudio brasileño que crea juegos y herramientas para inspirar y empoderar a creadores.',
+      'about.second': 'Nuestro proyecto debut, <em>Frontline</em>, representa nuestro compromiso con la innovación y la narrativa. Llevamos casi seis años construyendo con un equipo dedicado — todos impulsados por el amor a los juegos.',
+      'about.missionTitle': 'Nuestra misión',
+      'about.missionCopy': 'Fortalecer la escena brasileña de videojuegos entregando proyectos de clase mundial que exhiban creatividad y excelencia.',
+      'team.title': 'Nuestro equipo',
+      'contact.title': 'Contáctanos',
+      'contact.copy': '¿Quieres colaborar, hacer preguntas o compartir comentarios? Ponte en contacto — nos encantará saber de ti.',
+      'contact.name': 'Tu nombre',
+      'contact.email': 'Correo electrónico',
+      'contact.message': 'Tu mensaje',
+      'contact.send': 'Enviar mensaje',
+      'contact.sending': 'Enviando...',
+      'contact.success': '¡Mensaje enviado! Nos pondremos en contacto pronto.',
+      'contact.error': 'Algo salió mal. Inténtalo de nuevo más tarde.',
+      'footer.copy': '© <span id="year"></span> Neo Soft. Fundado por Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
+    },
+    zh: {
+      'nav.games': '游戏',
+      'nav.plugins': '插件',
+      'nav.news': '新闻',
+      'nav.careers': '招聘',
+      'nav.about': '关于',
+      'nav.team': '团队',
+      'nav.contact': '联系',
+      'nav.unmute': '开启音效',
+      'nav.mute': '关闭音效',
+      'nav.languageLabel': '选择语言',
+      'nav.menuTitle': '菜单',
+      'hero.title': '创造世界。<span class="text-purpleNeo">激发玩家。</span>',
+      'hero.subtitle': '巴西游戏工作室，以技术、创意与热情打造沉浸式体验。',
+      'hero.ctaGames': '探索游戏',
+      'hero.ctaPlugins': '查看插件',
+      'games.title': '我们的游戏',
+      'games.subtitle': '用热忱与尖端科技构建的世界。拖动浏览。',
+      'games.frontline': '一款将真实感、张力与叙事融合的沉浸式战术射击——现已登陆 Steam。',
+      'games.rampage': '一款节奏混乱的音乐格斗游戏，在多人模式中带来纯粹的肾上腺素、破坏与混乱。',
+      'games.dissociation': '一部心理恐怖作品，AI 操控你的每一步——无武器、无逃脱，只有求生。你还能分辨真实吗？',
+      'games.banana': '一场充满幽默的生存冒险，变异香蕉统治世界——你能阻止这场水果起义吗？',
+      'shared.learnMore': '了解更多 →',
+      'shared.backToTop': '返回顶部',
+      'carousel.prev': '上一项',
+      'carousel.next': '下一项',
+      'plugins.title': '我们的插件',
+      'plugins.subtitle': 'Fab 市场上架',
+      'plugins.world': '使用程序化地形、生物群落与资产布置，在 Unreal Engine 中打造广阔而动态的开放世界。',
+      'plugins.explosion': '添加完全复制、即插即用的爆炸效果，可自定义视觉与优化的物理表现。',
+      'plugins.view': '查看插件 →',
+      'news.title': '最新消息',
+      'news.frontline.date': '2025 年 9 月',
+      'news.frontline.title': 'Frontline 登陆 Steam',
+      'news.frontline.copy': '经过近六年开发，我们的首款作品正式发布——立即体验这场革命。',
+      'news.team.date': '2025 年 7 月',
+      'news.team.title': 'Neo Soft 扩充团队',
+      'news.team.copy': '我们在成长！Neo Soft 欢迎新人才，共同开启旅程的新篇章。',
+      'careers.title': '招聘',
+      'careers.copy': '我们正在招募！欢迎热衷于打造下一代体验的开发者、艺术家与设计师加入。帮助我们塑造互动娱乐的未来。',
+      'careers.apply': '立即申请',
+      'careers.team': '认识团队',
+      'careers.open': '招募职位',
+      'careers.roles.gameplay': '• 游戏玩法程序员（Unreal）',
+      'careers.roles.technical': '• 技术美术',
+      'careers.roles.environment': '• 3D 场景美术',
+      'careers.roles.narrative': '• 叙事设计师',
+      'about.title': '关于 Neo Soft',
+      'about.first': '由 <strong>Victor</strong> 于 2020 年创立，Neo Soft 是一家巴西工作室，打造激发并赋能创作者的游戏与工具。',
+      'about.second': '我们的首发项目 <em>Frontline</em> 体现了我们对创新与叙事的执着。近六年来，我们与一支敬业团队携手打造，只因热爱游戏。',
+      'about.missionTitle': '我们的使命',
+      'about.missionCopy': '通过交付世界级项目，展现创造力与卓越，壮大巴西游戏生态。',
+      'team.title': '我们的团队',
+      'contact.title': '联系我们',
+      'contact.copy': '想合作、提问或分享反馈？欢迎与我们联系——我们期待你的消息。',
+      'contact.name': '您的姓名',
+      'contact.email': '电子邮件',
+      'contact.message': '您的留言',
+      'contact.send': '发送信息',
+      'contact.sending': '正在发送…',
+      'contact.success': '信息已发送！我们会尽快回复。',
+      'contact.error': '出现问题。请稍后再试。',
+      'footer.copy': '© <span id="year"></span> Neo Soft. 由 Victor Henrique Mendonça Rodrigues 创立。• <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
+    },
+    ja: {
+      'nav.games': 'ゲーム',
+      'nav.plugins': 'プラグイン',
+      'nav.news': 'ニュース',
+      'nav.careers': '採用情報',
+      'nav.about': '概要',
+      'nav.team': 'チーム',
+      'nav.contact': 'お問い合わせ',
+      'nav.unmute': '効果音をオン',
+      'nav.mute': '効果音をオフ',
+      'nav.languageLabel': '言語を選択',
+      'nav.menuTitle': 'メニュー',
+      'hero.title': '世界を創造する。<span class="text-purpleNeo">プレイヤーを刺激する。</span>',
+      'hero.subtitle': 'テクノロジー、創造性、情熱で没入型体験を生み出すブラジルのゲームスタジオ。',
+      'hero.ctaGames': 'ゲームを見る',
+      'hero.ctaPlugins': 'プラグインを見る',
+      'games.title': '私たちのゲーム',
+      'games.subtitle': '情熱と最先端技術で作り上げた世界。ドラッグしてご覧ください。',
+      'games.frontline': 'リアリズム、緊張感、物語性を融合させた没入型タクティカルシューター — 現在 Steam で配信中。',
+      'games.rampage': '混沌としたリズムで展開する音楽系乱闘ゲーム。マルチプレイで純粋な興奮と破壊、カオスを体験。',
+      'games.dissociation': 'AI があなたの一挙手一投足を操るサイコホラー — 武器も逃げ場もなく、生き残りだけが目的。現実を見分けられますか？',
+      'games.banana': '突然変異したバナナが世界を支配するコミカルなサバイバルアドベンチャー — フルーツの反乱を止められるか？',
+      'shared.learnMore': 'さらに詳しく →',
+      'shared.backToTop': 'トップへ戻る',
+      'carousel.prev': '前へ',
+      'carousel.next': '次へ',
+      'plugins.title': '私たちのプラグイン',
+      'plugins.subtitle': 'Fab マーケット掲載',
+      'plugins.world': 'Unreal Engine でプロシージャル地形、バイオーム、アセット配置を使って広大でダイナミックなオープンワールドを構築。',
+      'plugins.explosion': '完全レプリケーション対応でネットワーク運用可能な爆発を追加。カスタマイズ可能な演出と最適化された物理を搭載。',
+      'plugins.view': 'プラグインを見る →',
+      'news.title': '最新ニュース',
+      'news.frontline.date': '2025年9月',
+      'news.frontline.title': 'Frontline が Steam でリリース',
+      'news.frontline.copy': '約6年の開発期間を経て、私たちのデビュー作が正式にローンチしました — 今すぐ革命を体験しよう。',
+      'news.team.date': '2025年7月',
+      'news.team.title': 'Neo Soft がチームを拡大',
+      'news.team.copy': '私たちは成長を続けています！Neo Soft は新たな才能を迎え入れ、次のチャプターへ進みます。',
+      'careers.title': '採用情報',
+      'careers.copy': '私たちは採用中です！次世代の体験づくりに情熱を持つ開発者、アーティスト、デザイナーを求めています。インタラクティブ・エンターテインメントの未来を共に形にしましょう。',
+      'careers.apply': '今すぐ応募',
+      'careers.team': 'チームを見る',
+      'careers.open': '募集中の職種',
+      'careers.roles.gameplay': '・ゲームプレイプログラマー（Unreal）',
+      'careers.roles.technical': '・テクニカルアーティスト',
+      'careers.roles.environment': '・3D環境アーティスト',
+      'careers.roles.narrative': '・ナラティブデザイナー',
+      'about.title': 'Neo Soft について',
+      'about.first': '<strong>Victor</strong> によって 2020 年に設立された Neo Soft は、クリエイターを刺激し力を与えるゲームとツールを開発するブラジルのスタジオです。',
+      'about.second': '私たちのデビュー作 <em>Frontline</em> は、イノベーションとストーリーテリングへのこだわりを体現しています。約 6 年間、献身的なチームとともに制作を進めてきました — すべてはゲームへの愛から。',
+      'about.missionTitle': '私たちの使命',
+      'about.missionCopy': '創造性と卓越性を示す世界水準のプロジェクトを届け、ブラジルのゲームシーンを強化すること。',
+      'team.title': '私たちのチーム',
+      'contact.title': 'お問い合わせ',
+      'contact.copy': 'コラボレーションの相談、質問、フィードバックなど、お気軽にご連絡ください — 皆さまからのメッセージをお待ちしています。',
+      'contact.name': 'お名前',
+      'contact.email': 'メールアドレス',
+      'contact.message': 'メッセージ',
+      'contact.send': 'メッセージを送信',
+      'contact.sending': '送信中…',
+      'contact.success': 'メッセージを送信しました！追ってご連絡いたします。',
+      'contact.error': '問題が発生しました。後でもう一度お試しください。',
+      'footer.copy': '© <span id="year"></span> Neo Soft. Victor Henrique Mendonça Rodrigues により設立。• <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
+    }
+  };
 
-  // State
+  const storageKey = 'neoSoftLang';
+  let currentLang = 'en';
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored && translations[stored]) currentLang = stored;
+  } catch (err) {
+    currentLang = 'en';
+  }
+
+  const setDocumentLang = (lang) => {
+    const map = { pt: 'pt-BR', es: 'es-ES', en: 'en', zh: 'zh-CN', ja: 'ja-JP' };
+    document.documentElement.lang = map[lang] || 'en';
+  };
+
+  const t = (key) => translations[currentLang]?.[key] ?? translations.en[key] ?? key;
+
   let muted = true;
-  const refreshMuteBtn = () => { if (muteBtn) muteBtn.textContent = muted ? 'Unmute SFX' : 'Mute SFX'; if (muteBtnMobile) muteBtnMobile.textContent = muted ? 'Unmute SFX' : 'Mute SFX'; }
-  refreshMuteBtn();
+
+  function refreshMuteBtn(){
+    const label = muted ? t('nav.unmute') : t('nav.mute');
+    if (muteBtn) muteBtn.textContent = label;
+    if (muteBtnMobile) muteBtnMobile.textContent = label;
+  }
+
+  const applyTranslations = (lang = currentLang) => {
+    if (!translations[lang]) lang = 'en';
+    currentLang = lang;
+    try { localStorage.setItem(storageKey, lang); } catch (err) {}
+    setDocumentLang(lang);
+    if (languageSelect) languageSelect.value = lang;
+    if (languageSelectMobile) languageSelectMobile.value = lang;
+    $$('[data-i18n]').forEach(el => {
+      const key = el.dataset.i18n;
+      const value = translations[lang]?.[key];
+      if (value !== undefined) el.innerHTML = value;
+    });
+    $$('[data-i18n-placeholder]').forEach(el => {
+      const key = el.dataset.i18nPlaceholder;
+      const value = translations[lang]?.[key];
+      if (value !== undefined) el.setAttribute('placeholder', value);
+    });
+    $$('[data-i18n-aria-label]').forEach(el => {
+      const key = el.dataset.i18nAriaLabel;
+      const value = translations[lang]?.[key];
+      if (value !== undefined) el.setAttribute('aria-label', value);
+    });
+    updateYear();
+    refreshMuteBtn();
+  };
+
+  const updateYear = () => {
+    const span = $('#year');
+    if (span) span.textContent = new Date().getFullYear();
+  };
+
+  applyTranslations(currentLang);
+  updateYear();
+
   if (sfxToggle) sfxToggle.checked = !muted;
+
+  languageSelect && languageSelect.addEventListener('change', (e) => applyTranslations(e.target.value));
+  languageSelectMobile && languageSelectMobile.addEventListener('change', (e) => applyTranslations(e.target.value));
 
   // Navbar scroll / back-to-top
   const onScroll = () => {
@@ -178,25 +557,25 @@
   // EmailJS form
   contactForm && contactForm.addEventListener('submit', function(e){
     e.preventDefault();
-    const btn = $('#sendBtn');
+    const btn = sendBtn;
     const original = btn.innerHTML;
     btn.disabled = true;
     btn.classList.add('opacity-60','cursor-not-allowed');
-    btn.innerHTML = `<span class="loader mr-2"></span> Sending...`;
+    btn.innerHTML = `<span class="loader mr-2"></span> ${t('contact.sending')}`;
 
     emailjs.sendForm('service_47lqkyt','template_3yzo1bv', this)
       .then(function(res){
         console.log('Email sent', res.status);
         blip(540, 0.1, 'square');
-        formFeedback.classList.remove('hidden');
+        if (formFeedback) formFeedback.classList.remove('hidden');
         btn.disabled = false;
         btn.classList.remove('opacity-60','cursor-not-allowed');
         btn.innerHTML = original;
         contactForm.reset();
-        setTimeout(()=> formFeedback.classList.add('hidden'), 3000);
+        setTimeout(()=> formFeedback && formFeedback.classList.add('hidden'), 3000);
       }, function(err){
         console.error('Email error', err);
-        alert('Something went wrong. Please try again later.');
+        alert(t('contact.error'));
         btn.disabled = false;
         btn.classList.remove('opacity-60','cursor-not-allowed');
         btn.innerHTML = original;


### PR DESCRIPTION
## Summary
- add Chinese and Japanese options to the desktop and mobile language selectors
- provide full Simplified Chinese and Japanese translations for all localized interface strings and update document language mapping

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d0553c6c832f80bf641c15c90233