### PR TITLE
Add Discord link to social follow section

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,6 +316,20 @@
               <span class="block text-xs text-white/50">linkedin.com/company/neeeosoft</span>
             </div>
           </a>
+          <a href="https://discord.gg/HA2CBfdCFT" target="_blank" rel="noopener noreferrer" class="group inline-flex items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 transition hover:border-purple-400/60 hover:bg-white/10" aria-label="Open Neo Soft on Discord" data-i18n-aria-label="contact.discordAria">
+            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-purpleNeo to-fuchsiaNeo text-xs font-semibold tracking-wide">DC</span>
+            <div>
+              <span class="block text-sm font-semibold text-white" data-i18n="contact.socialDiscord">Discord / Neo Soft</span>
+              <span class="block text-xs text-white/50">discord.gg/HA2CBfdCFT</span>
+            </div>
+          </a>
+          <a href="https://www.youtube.com/@NeoSoft-m2e" target="_blank" rel="noopener noreferrer" class="group inline-flex items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 transition hover:border-purple-400/60 hover:bg-white/10" aria-label="Open Neo Soft on YouTube" data-i18n-aria-label="contact.youtubeAria">
+            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-purpleNeo to-fuchsiaNeo text-xs font-semibold tracking-wide">YT</span>
+            <div>
+              <span class="block text-sm font-semibold text-white" data-i18n="contact.socialYouTube">YouTube @NeoSoft-m2e</span>
+              <span class="block text-xs text-white/50">youtube.com/@NeoSoft-m2e</span>
+            </div>
+          </a>
         </div>
       </div>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -89,6 +89,10 @@
       'contact.socialLinkedIn': 'LinkedIn / Neo Soft',
       'contact.instagramAria': 'Open Neo Soft on Instagram',
       'contact.linkedinAria': 'Open Neo Soft on LinkedIn',
+      'contact.socialDiscord': 'Discord / Neo Soft',
+      'contact.discordAria': 'Open Neo Soft on Discord',
+      'contact.socialYouTube': 'YouTube @NeoSoft-m2e',
+      'contact.youtubeAria': 'Open Neo Soft on YouTube',
       'footer.copy': '© <span id="year"></span> Neo Soft. Founded by Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
     },
     pt: {
@@ -159,6 +163,10 @@
       'contact.socialLinkedIn': 'LinkedIn / Neo Soft',
       'contact.instagramAria': 'Abrir Neo Soft no Instagram',
       'contact.linkedinAria': 'Abrir Neo Soft no LinkedIn',
+      'contact.socialDiscord': 'Discord / Neo Soft',
+      'contact.discordAria': 'Abrir Neo Soft no Discord',
+      'contact.socialYouTube': 'YouTube @NeoSoft-m2e',
+      'contact.youtubeAria': 'Abrir Neo Soft no YouTube',
       'footer.copy': '© <span id="year"></span> Neo Soft. Fundada por Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
     },
     es: {
@@ -229,6 +237,10 @@
       'contact.socialLinkedIn': 'LinkedIn / Neo Soft',
       'contact.instagramAria': 'Abrir Neo Soft en Instagram',
       'contact.linkedinAria': 'Abrir Neo Soft en LinkedIn',
+      'contact.socialDiscord': 'Discord / Neo Soft',
+      'contact.discordAria': 'Abrir Neo Soft en Discord',
+      'contact.socialYouTube': 'YouTube @NeoSoft-m2e',
+      'contact.youtubeAria': 'Abrir Neo Soft en YouTube',
       'footer.copy': '© <span id="year"></span> Neo Soft. Fundado por Victor Henrique Mendonça Rodrigues. • <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
     },
     zh: {
@@ -299,6 +311,10 @@
       'contact.socialLinkedIn': 'LinkedIn / Neo Soft',
       'contact.instagramAria': '在 Instagram 打开 Neo Soft',
       'contact.linkedinAria': '在 LinkedIn 打开 Neo Soft',
+      'contact.socialDiscord': 'Discord / Neo Soft',
+      'contact.discordAria': '在 Discord 打开 Neo Soft',
+      'contact.socialYouTube': 'YouTube @NeoSoft-m2e',
+      'contact.youtubeAria': '在 YouTube 打开 Neo Soft',
       'footer.copy': '© <span id="year"></span> Neo Soft. 由 Victor Henrique Mendonça Rodrigues 创立。• <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
     },
     ja: {
@@ -369,6 +385,10 @@
       'contact.socialLinkedIn': 'LinkedIn / Neo Soft',
       'contact.instagramAria': 'Instagram で Neo Soft を開く',
       'contact.linkedinAria': 'LinkedIn で Neo Soft を開く',
+      'contact.socialDiscord': 'Discord / Neo Soft',
+      'contact.discordAria': 'Discord で Neo Soft を開く',
+      'contact.socialYouTube': 'YouTube @NeoSoft-m2e',
+      'contact.youtubeAria': 'YouTube で Neo Soft を開く',
       'footer.copy': '© <span id="year"></span> Neo Soft. Victor Henrique Mendonça Rodrigues により設立。• <a href="mailto:contact@neeosoft.com.br" class="hover:text-purple-300">contact@neeosoft.com.br</a>'
     }
   };


### PR DESCRIPTION
## Summary
- add Neo Soft's Discord invite to the Contact section's social follow cards
- localize the Discord label and aria text across all supported languages

## Testing
- not run (static site change)

------
https://chatgpt.com/codex/tasks/task_e_68e405cc83d4832fbc5037127373edc7