### PR TITLE
Improve language selector styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,6 +78,72 @@ section[id] {
 .mobile-menu a{ display:block; padding:.5rem 0; border-bottom:1px solid rgba(255,255,255,.06); }
 .mobile-menu a:last-child{ border-bottom:0; }
 
+.language-select{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  padding:2px;
+  border-radius:9999px;
+  background:linear-gradient(135deg, rgba(209,75,240,.7), rgba(155,93,229,.25));
+  box-shadow:0 8px 24px rgba(155,93,229,.25);
+  transition:background .25s ease, box-shadow .25s ease, transform .2s ease;
+}
+
+.language-select:hover{
+  background:linear-gradient(135deg, rgba(209,75,240,.85), rgba(155,93,229,.4));
+  box-shadow:0 12px 30px rgba(155,93,229,.35);
+  transform:translateY(-1px);
+}
+
+.language-select:focus-within{
+  box-shadow:0 0 0 2px rgba(209,75,240,.3),0 10px 28px rgba(155,93,229,.4);
+}
+
+.language-select::after{
+  content:'';
+  position:absolute;
+  right:14px;
+  width:8px;
+  height:8px;
+  border:2px solid rgba(236,233,255,.75);
+  border-left:0;
+  border-top:0;
+  transform:rotate(45deg);
+  pointer-events:none;
+  transition:transform .2s ease;
+}
+
+.language-select:hover::after{ transform:translateY(1px) rotate(45deg); }
+
+.language-select__field{
+  appearance:none;
+  -webkit-appearance:none;
+  border:0;
+  background:rgba(7,1,15,.88);
+  color:rgba(255,255,255,.9);
+  font-weight:600;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  padding:.45rem 2.4rem .45rem 1rem;
+  border-radius:9999px;
+  min-width:110px;
+  cursor:pointer;
+}
+
+.language-select__field:focus{
+  outline:none;
+  background:rgba(12,1,24,.95);
+}
+
+.language-select__field option{
+  color:#0f0018;
+  background:white;
+}
+
+.language-select--mobile{ width:100%; margin-top:.4rem; }
+
+.language-select--mobile .language-select__field{ width:100%; }
+
 /* Responsive Cards */
 @media (max-width: 640px){
   #gamesTrack,

--- a/index.html
+++ b/index.html
@@ -72,13 +72,15 @@
       <!-- Mobile controls -->
       <div class="flex items-center gap-3">
         <label class="sr-only" for="languageSelect" data-i18n="nav.languageLabel">Select language</label>
-        <select id="languageSelect" class="hidden md:inline-block px-2 py-1 text-xs rounded-md border border-white/20 bg-black/40 hover:border-purple-400/50 focus:outline-none focus:border-purpleNeo" data-i18n-aria-label="nav.languageLabel">
-          <option value="en">EN</option>
-          <option value="pt">PT</option>
-          <option value="es">ES</option>
-          <option value="zh">ZH</option>
-          <option value="ja">JA</option>
-        </select>
+        <div class="language-select hidden md:inline-flex" data-i18n-aria-label="nav.languageLabel">
+          <select id="languageSelect" class="language-select__field text-xs" aria-label="Select language">
+            <option value="en">EN</option>
+            <option value="pt">PT</option>
+            <option value="es">ES</option>
+            <option value="zh">ZH</option>
+            <option value="ja">JA</option>
+          </select>
+        </div>
         <button id="muteBtn" class="hidden md:inline-block px-3 py-1.5 rounded-md text-xs border border-white/15 hover:border-purple-400/50 hover:text-purple-300" aria-label="Toggle SFX" data-i18n="nav.unmute">Unmute SFX</button>
         <button id="hamburger" class="md:hidden h-9 w-9 grid place-items-center border border-white/20 rounded" aria-label="Open menu" aria-expanded="false">
           <span class="hamburger-line"></span>
@@ -92,13 +94,15 @@
     <div id="mobileMenu" class="mobile-menu hidden md:hidden" aria-label="Mobile menu">
       <div class="flex items-center justify-between">
         <span class="text-xs font-semibold" data-i18n="nav.menuTitle">Menu</span>
-        <select id="languageSelectMobile" class="px-2 py-1 text-xs rounded-md border border-white/20 bg-black/40 focus:outline-none focus:border-purpleNeo" data-i18n-aria-label="nav.languageLabel">
-          <option value="en">EN</option>
-          <option value="pt">PT</option>
-          <option value="es">ES</option>
-          <option value="zh">ZH</option>
-          <option value="ja">JA</option>
-        </select>
+        <div class="language-select language-select--mobile" data-i18n-aria-label="nav.languageLabel">
+          <select id="languageSelectMobile" class="language-select__field text-xs" aria-label="Select language">
+            <option value="en">EN</option>
+            <option value="pt">PT</option>
+            <option value="es">ES</option>
+            <option value="zh">ZH</option>
+            <option value="ja">JA</option>
+          </select>
+        </div>
       </div>
       <a href="#games" data-i18n="nav.games">Games</a>
       <a href="#plugins" data-i18n="nav.plugins">Plugins</a>


### PR DESCRIPTION
## Summary
- wrap the desktop and mobile language dropdowns in a custom component with a refined visual presentation
- add bespoke CSS for the selector to deliver a glassy gradient pill, custom caret, and improved hover/focus states

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4121ade18832f9aa4498dd6f694d0