### PR TITLE
Add flip animation to team member cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -55,11 +55,26 @@ section[id] {
 .news-summary{ color:rgba(255,255,255,.85); font-size:.95rem; }
 
 /* Team */
-.team-card{ text-align:center; border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:rgba(255,255,255,.05); transition:background .2s ease; }
-.team-card:hover{ background:rgba(255,255,255,.1); }
-.team-avatar{ height:96px; width:96px; margin:0 auto 1rem; border-radius:9999px; background:linear-gradient(135deg, var(--purple), var(--fuchsia)); box-shadow:0 0 40px rgba(155,93,229,.35); }
+.team-card{ position:relative; min-height:300px; border-radius:.75rem; perspective:1200px; outline:none; cursor:pointer; }
+.team-card:focus{ outline:none; }
+.team-card:focus-visible{ box-shadow:0 0 0 3px rgba(209,75,240,.45); }
+.team-card-inner{ position:relative; height:100%; width:100%; transform-style:preserve-3d; transition:transform .65s cubic-bezier(.25,.8,.25,1); }
+.team-card:hover .team-card-inner,
+.team-card:focus-visible .team-card-inner{ transform:rotateY(180deg); }
+.team-card-face{ position:absolute; inset:0; padding:1.5rem; border-radius:.75rem; border:1px solid rgba(255,255,255,.1); background:rgba(255,255,255,.05); text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:.65rem; backface-visibility:hidden; transition:background .35s ease, border-color .35s ease; }
+.team-card-front{ transform:rotateY(0deg); }
+.team-card:hover .team-card-front,
+.team-card:focus-visible .team-card-front{ background:rgba(255,255,255,.1); }
+.team-card-back{ background:linear-gradient(135deg, rgba(155,93,229,.25), rgba(209,75,240,.2)); transform:rotateY(180deg); border-color:rgba(216,180,254,.25); }
+.team-card-back .team-name{ color:#f5e1ff; }
+.team-avatar{ height:96px; width:96px; margin:0 0 1rem; border-radius:9999px; background:linear-gradient(135deg, var(--purple), var(--fuchsia)); box-shadow:0 0 40px rgba(155,93,229,.35); }
 .team-name{ font-weight:600; }
-.team-role{ font-size:.85rem; color:rgba(216,180,254,.8); }
+.team-role{ font-size:.85rem; color:rgba(216,180,254,.8); margin:0; }
+.team-bio{ font-size:.85rem; color:rgba(255,255,255,.78); line-height:1.5; }
+
+@media (prefers-reduced-motion: reduce){
+  .team-card-inner{ transition:none; }
+}
 
 /* Inputs / buttons */
 .input, .textarea{ border:1px solid rgba(255,255,255,.15); background:rgba(255,255,255,.05); border-radius:.5rem; padding:.6rem .75rem; color:white; }

--- a/index.html
+++ b/index.html
@@ -277,11 +277,77 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
       <h2 class="text-2xl sm:text-3xl font-bold text-purple-200 mb-8 sm:mb-10" data-i18n="team.title">Our Team</h2>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <div class="team-card"><div class="team-avatar"><img src="img/victor.jpg" alt="Victor Henrique" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Victor Henrique</h3><p class="team-role">Founder & Senior Developer</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/hiury.jpg" alt="Hiury Francisco" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Hiury Francisco</h3><p class="team-role">Video Editor & Production Lead</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/josegabriel.jpg" alt="José Gabriel" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">José Gabriel</h3><p class="team-role">Programmer</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/henriquecoelhozama(alice).jpg" alt="Henrique Coelho Zama" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Henrique Coelho Zama</h3><p class="team-role">Writer</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/isabelbrito.jpg" alt="Isabel Brito" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Isabel Brito</h3><p class="team-role">Voice Director</p></div>     </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar"><img src="img/victor.jpg" alt="Victor Henrique" class="rounded-full w-24 h-24 object-cover mx-auto"></div>
+              <h3 class="team-name">Victor Henrique</h3>
+              <p class="team-role">Founder &amp; Senior Developer</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Victor Henrique</h3>
+              <p class="team-role">Founder &amp; Senior Developer</p>
+              <p class="team-bio">Architects gameplay systems and Unreal Engine plugins while guiding Neo Soft&rsquo;s technical vision.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar"><img src="img/hiury.jpg" alt="Hiury Francisco" class="rounded-full w-24 h-24 object-cover mx-auto"></div>
+              <h3 class="team-name">Hiury Francisco</h3>
+              <p class="team-role">Video Editor &amp; Production Lead</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Hiury Francisco</h3>
+              <p class="team-role">Video Editor &amp; Production Lead</p>
+              <p class="team-bio">Shapes trailers, cinematics, and marketing beats while coordinating production timelines with the team.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar"><img src="img/josegabriel.jpg" alt="José Gabriel" class="rounded-full w-24 h-24 object-cover mx-auto"></div>
+              <h3 class="team-name">José Gabriel</h3>
+              <p class="team-role">Programmer</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">José Gabriel</h3>
+              <p class="team-role">Programmer</p>
+              <p class="team-bio">Builds gameplay features and tools, ensuring smooth performance across Neo Soft&rsquo;s projects.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar"><img src="img/henriquecoelhozama(alice).jpg" alt="Henrique Coelho Zama" class="rounded-full w-24 h-24 object-cover mx-auto"></div>
+              <h3 class="team-name">Henrique Coelho Zama</h3>
+              <p class="team-role">Writer</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Henrique Coelho Zama</h3>
+              <p class="team-role">Writer</p>
+              <p class="team-bio">Crafts immersive narratives, characters, and lore that give each universe its unique voice.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar"><img src="img/isabelbrito.jpg" alt="Isabel Brito" class="rounded-full w-24 h-24 object-cover mx-auto"></div>
+              <h3 class="team-name">Isabel Brito</h3>
+              <p class="team-role">Voice Director</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Isabel Brito</h3>
+              <p class="team-role">Voice Director</p>
+              <p class="team-bio">Directs voice talent and ensures performances capture the emotional beats of each storyline.</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- convert the team member markup into front/back card faces so hovering reveals a brief bio
- add 3D flip styling, focus handling, and reduced-motion fallback for the team cards

## Testing
- Manual verification via local browser

------
https://chatgpt.com/codex/tasks/task_e_68e41a407b04832fb8075125c41a9b85