### PR TITLE
Add interactive flip animation to team cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -55,11 +55,28 @@ section[id] {
 .news-summary{ color:rgba(255,255,255,.85); font-size:.95rem; }
 
 /* Team */
-.team-card{ text-align:center; border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:rgba(255,255,255,.05); transition:background .2s ease; }
-.team-card:hover{ background:rgba(255,255,255,.1); }
-.team-avatar{ height:96px; width:96px; margin:0 auto 1rem; border-radius:9999px; background:linear-gradient(135deg, var(--purple), var(--fuchsia)); box-shadow:0 0 40px rgba(155,93,229,.35); }
-.team-name{ font-weight:600; }
-.team-role{ font-size:.85rem; color:rgba(216,180,254,.8); }
+.team-card{ position:relative; perspective:1200px; }
+.team-card:focus{ outline:none; }
+.team-card:focus-visible{ outline:2px solid rgba(155,93,229,.6); outline-offset:6px; border-radius:.95rem; }
+.team-card-inner{ position:relative; width:100%; min-height:260px; transform-style:preserve-3d; transition:transform .6s ease; }
+.team-card:hover .team-card-inner,
+.team-card:focus-visible .team-card-inner{ transform:rotateY(180deg); }
+.team-card-face{ position:absolute; inset:0; padding:1.75rem 1.5rem; border-radius:.75rem; border:1px solid rgba(255,255,255,.1); background:rgba(255,255,255,.05); display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; gap:.75rem; backface-visibility:hidden; transition:background .3s ease, border-color .3s ease; }
+.team-card:hover .team-card-face,
+.team-card:focus-visible .team-card-face{ background:rgba(255,255,255,.1); border-color:rgba(255,255,255,.18); }
+.team-card-back{ transform:rotateY(180deg); padding:2rem 1.75rem; gap:.65rem; }
+.team-avatar{ height:96px; width:96px; margin:0 auto; border-radius:9999px; background:linear-gradient(135deg, var(--purple), var(--fuchsia)); box-shadow:0 0 40px rgba(155,93,229,.35); overflow:hidden; }
+.team-avatar img{ width:100%; height:100%; object-fit:cover; border-radius:inherit; }
+.team-name{ font-weight:600; font-size:1.1rem; }
+.team-role{ font-size:.85rem; color:rgba(216,180,254,.8); letter-spacing:.01em; text-transform:uppercase; }
+.team-bio{ font-size:.85rem; color:rgba(255,255,255,.72); line-height:1.5; }
+
+@media (prefers-reduced-motion: reduce){
+  .team-card-inner{ transition:none; }
+  .team-card:hover .team-card-inner,
+  .team-card:focus-visible .team-card-inner{ transform:none; }
+  .team-card-face{ transition:background .2s ease, border-color .2s ease; }
+}
 
 /* Inputs / buttons */
 .input, .textarea{ border:1px solid rgba(255,255,255,.15); background:rgba(255,255,255,.05); border-radius:.5rem; padding:.6rem .75rem; color:white; }

--- a/index.html
+++ b/index.html
@@ -277,11 +277,87 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
       <h2 class="text-2xl sm:text-3xl font-bold text-purple-200 mb-8 sm:mb-10" data-i18n="team.title">Our Team</h2>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <div class="team-card"><div class="team-avatar"><img src="img/victor.jpg" alt="Victor Henrique" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Victor Henrique</h3><p class="team-role">Founder & Senior Developer</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/hiury.jpg" alt="Hiury Francisco" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Hiury Francisco</h3><p class="team-role">Video Editor & Production Lead</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/josegabriel.jpg" alt="José Gabriel" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">José Gabriel</h3><p class="team-role">Programmer</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/henriquecoelhozama(alice).jpg" alt="Henrique Coelho Zama" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Henrique Coelho Zama</h3><p class="team-role">Writer</p></div>
-        <div class="team-card"><div class="team-avatar"><img src="img/isabelbrito.jpg" alt="Isabel Brito" class="rounded-full w-24 h-24 object-cover mx-auto"></div><h3 class="team-name">Isabel Brito</h3><p class="team-role">Voice Director</p></div>     </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar">
+                <img src="img/victor.jpg" alt="Portrait of Victor Henrique" />
+              </div>
+              <h3 class="team-name">Victor Henrique</h3>
+              <p class="team-role">Founder &amp; Senior Developer</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Victor Henrique</h3>
+              <p class="team-role">Founder &amp; Senior Developer</p>
+              <p class="team-bio">Leads Neo Soft’s creative direction and builds Unreal Engine experiences, balancing gameplay, tools, and storytelling.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar">
+                <img src="img/hiury.jpg" alt="Portrait of Hiury Francisco" />
+              </div>
+              <h3 class="team-name">Hiury Francisco</h3>
+              <p class="team-role">Video Editor &amp; Production Lead</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Hiury Francisco</h3>
+              <p class="team-role">Video Editor &amp; Production Lead</p>
+              <p class="team-bio">Transforms game footage into cinematic trailers and coordinates marketing assets that capture each project’s energy.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar">
+                <img src="img/josegabriel.jpg" alt="Portrait of José Gabriel" />
+              </div>
+              <h3 class="team-name">José Gabriel</h3>
+              <p class="team-role">Programmer</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">José Gabriel</h3>
+              <p class="team-role">Programmer</p>
+              <p class="team-bio">Builds gameplay systems and optimizes performance so our Unreal projects feel smooth, responsive, and alive.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar">
+                <img src="img/henriquecoelhozama(alice).jpg" alt="Portrait of Henrique Coelho Zama" />
+              </div>
+              <h3 class="team-name">Henrique Coelho Zama</h3>
+              <p class="team-role">Writer</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Henrique Coelho Zama</h3>
+              <p class="team-role">Writer</p>
+              <p class="team-bio">Crafts narrative arcs, dialogue, and world-building that immerse players in the emotional core of our stories.</p>
+            </div>
+          </div>
+        </div>
+        <div class="team-card" tabindex="0">
+          <div class="team-card-inner">
+            <div class="team-card-face team-card-front">
+              <div class="team-avatar">
+                <img src="img/isabelbrito.jpg" alt="Portrait of Isabel Brito" />
+              </div>
+              <h3 class="team-name">Isabel Brito</h3>
+              <p class="team-role">Voice Director</p>
+            </div>
+            <div class="team-card-face team-card-back">
+              <h3 class="team-name">Isabel Brito</h3>
+              <p class="team-role">Voice Director</p>
+              <p class="team-bio">Guides casting and performance for voice talent, ensuring every character sounds authentic and emotionally grounded.</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add a 3D flip animation to each team member card to reveal role details on hover
- introduce short bios, improved imagery alt text, and focus states for keyboard users
- respect reduced-motion preferences to keep the cards accessible

## Testing
- Manually opened the site in a local browser

------
https://chatgpt.com/codex/tasks/task_e_68e42809b35c832fb69f2961ffcf2d68