### PR TITLE
Add paginated carousels for games and plugins

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -110,9 +110,15 @@ section[id] {
 .services-track{ display:flex; transition:transform .6s ease; will-change:transform; }
 .services-slide{ flex:0 0 100%; box-sizing:border-box; padding:0 .25rem; display:grid; gap:1rem; }
 .services-slide .card3d{ width:100%; }
+.carousel-window{ overflow:hidden; padding-bottom:.5rem; }
+.carousel-track{ display:flex; transition:transform .6s ease; will-change:transform; }
+.carousel-slide{ flex:0 0 100%; box-sizing:border-box; padding:0 .25rem; display:grid; gap:1rem; justify-items:center; }
+.carousel-slide .card3d{ width:100%; max-width:340px; margin-inline:auto; }
 .card3d--placeholder{ visibility:hidden; pointer-events:none; }
 @media (min-width:640px){ .services-slide{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
+@media (min-width:640px){ .carousel-slide{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
 @media (min-width:1024px){ .services-slide{ grid-template-columns:repeat(3,minmax(0,1fr)); } }
+@media (min-width:1024px){ .carousel-slide{ grid-template-columns:repeat(3,minmax(0,1fr)); } }
 .card3d:hover{ background:rgba(255,255,255,.08); }
 .card3d-img{ position:relative; background:rgba(0,0,0,.3); aspect-ratio:16/9; overflow:hidden; }
 .card3d-img img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; opacity:.75; }
@@ -138,12 +144,13 @@ section[id] {
 .carousel-controls{ position:absolute; top:50%; left:-50px; right:-50px; display:flex; align-items:center; justify-content:space-between; pointer-events:none; transform:translateY(-50%); }
 .carousel-controls button{ pointer-events:auto; height:40px; width:40px; border-radius:9999px; background:rgba(255,255,255,.1); border:1px solid rgba(255,255,255,.2); backdrop-filter: blur(8px); }
 .carousel-controls button:hover{ background:rgba(255,255,255,.2); }
+.carousel-controls button[disabled]{ opacity:.4; cursor:not-allowed; background:rgba(255,255,255,.08); }
 
 @media (max-width:640px){
   .carousel-controls{ top:100%; left:0; right:0; transform:none; margin-top:.75rem; justify-content:center; gap:.75rem; }
 }
 
-#gamesTrack, #pluginsTrack{ scroll-snap-type:x proximity; padding-bottom:.5rem; }
+#gamesTrack, #pluginsTrack{ padding-bottom:.5rem; }
 
 /* News cards */
 .news-card{ border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:linear-gradient(135deg, rgba(255,255,255,.05), transparent); }

--- a/index.html
+++ b/index.html
@@ -170,39 +170,47 @@
   <section id="games" class="section-gradient py-20 sm:py-24 bg-black">
     <div class="max-w-7xl mx-auto px-4 sm:px-6">
       <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6" data-i18n="games.title">Our Games</h2>
-      <p class="text-white/60 mb-6 max-w-3xl" data-i18n="games.subtitle">Worlds built with heart and cutting-edge tech. Drag to explore.</p>
+      <p class="text-white/60 mb-6 max-w-3xl" data-i18n="games.subtitle">Worlds built with heart and cutting-edge tech. Use the arrows to explore.</p>
       <div class="relative">
-        <div id="gamesTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/frontline.png" alt="Frontline key art" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Frontline</h3>
-              <p class="card3d-desc" data-i18n="games.frontline">An immersive tactical shooter combining realism, intensity, and storytelling — coming soon to Steam. Wishlist now.</p>
-              <a href="https://store.steampowered.com/app/1772220/Frontline_New_Revolution/" target="_blank" rel="noopener" class="card3d-link" data-i18n="shared.learnMore">Learn More →</a>
+        <div class="carousel-window">
+          <div id="gamesTrack" class="carousel-track" role="group" aria-roledescription="carousel" aria-label="Our games carousel">
+            <div class="carousel-slide" aria-hidden="false">
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/frontline.png" alt="Frontline key art" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">Frontline</h3>
+                  <p class="card3d-desc" data-i18n="games.frontline">An immersive tactical shooter combining realism, intensity, and storytelling — coming soon to Steam. Wishlist now.</p>
+                  <a href="https://store.steampowered.com/app/1772220/Frontline_New_Revolution/" target="_blank" rel="noopener" class="card3d-link" data-i18n="shared.learnMore">Learn More →</a>
+                </div>
+              </div>
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/rampagerush.jpg" alt="Rampage Rush concept art" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">Rampage Rush</h3>
+                  <p class="card3d-desc" data-i18n="games.rampage">A musical brawler with a chaotic rhythm that offers pure adrenaline, destruction and chaos in multiplayer mode.</p>
+                  <!-- <a href="#" class="card3d-link">Learn More →</a> -->
+                </div>
+              </div>
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/dissociation.jpg" alt="Bananapocalypse artwork" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">Dissociation</h3>
+                  <p class="card3d-desc" data-i18n="games.dissociation">A psychological horror where an AI manipulates your every move — no weapons, no escape, only survival. Do you know what’s real?</p>
+                  <!-- <a href="#" class="card3d-link">Learn More →</a> -->
+                </div>
+              </div>
             </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/rampagerush.jpg" alt="Rampage Rush concept art" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Rampage Rush</h3>
-              <p class="card3d-desc" data-i18n="games.rampage">A musical brawler with a chaotic rhythm that offers pure adrenaline, destruction and chaos in multiplayer mode.</p>
-              <!-- <a href="#" class="card3d-link">Learn More →</a> -->
-            </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/dissociation.jpg" alt="Bananapocalypse artwork" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Dissociation</h3>
-              <p class="card3d-desc" data-i18n="games.dissociation">A psychological horror where an AI manipulates your every move — no weapons, no escape, only survival. Do you know what’s real?</p>
-              <!-- <a href="#" class="card3d-link">Learn More →</a> -->
-            </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/banapocalypse.png" alt="Bananapocalypse artwork" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Bananapocalypse</h3>
-              <p class="card3d-desc" data-i18n="games.banana">Um jogo co-op onde todos os jogadores são macacos fugindo de um laboratório — todos precisam correr e escapar enquanto fazem macacagens.</p>
-              <!-- <a href="#" class="card3d-link">Learn More →</a> -->
+            <div class="carousel-slide" aria-hidden="true">
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/banapocalypse.png" alt="Bananapocalypse artwork" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">Bananapocalypse</h3>
+                  <p class="card3d-desc" data-i18n="games.banana">Um jogo co-op onde todos os jogadores são macacos fugindo de um laboratório — todos precisam correr e escapar enquanto fazem macacagens.</p>
+                  <!-- <a href="#" class="card3d-link">Learn More →</a> -->
+                </div>
+              </div>
+              <div class="card3d card3d--placeholder" aria-hidden="true"></div>
+              <div class="card3d card3d--placeholder" aria-hidden="true"></div>
             </div>
           </div>
         </div>
@@ -293,21 +301,26 @@
         <span class="text-xs text-purple-300/70" data-i18n="plugins.subtitle">Fab marketplace listings</span>
       </div>
       <div class="relative">
-        <div id="pluginsTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/WorldProceduralGeneratorPlugin.jpg" alt="World Procedural Generator Plugin cover" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">World Procedural Generator Plugin</h3>
-              <p class="card3d-desc" data-i18n="plugins.world">Create vast and dynamic open worlds in Unreal Engine with procedural terrain, biomes, and asset placement.</p>
-              <a href="https://www.fab.com/pt-br/listings/5b18f63c-894d-40b8-846a-bf4670ee9eeb" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
-            </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/ReplicatedExplosionPlugin.jpg" alt="Replicated Explosion Plugin cover" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Replicated Explosion Plugin</h3>
-              <p class="card3d-desc" data-i18n="plugins.explosion">Add fully replicated, network-ready explosions with customizable effects and optimized physics.</p>
-              <a href="https://www.fab.com/pt-br/listings/13134d3a-256f-44bc-9052-3dd69e87932d" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
+        <div class="carousel-window">
+          <div id="pluginsTrack" class="carousel-track" role="group" aria-roledescription="carousel" aria-label="Our plugins carousel">
+            <div class="carousel-slide" aria-hidden="false">
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/WorldProceduralGeneratorPlugin.jpg" alt="World Procedural Generator Plugin cover" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">World Procedural Generator Plugin</h3>
+                  <p class="card3d-desc" data-i18n="plugins.world">Create vast and dynamic open worlds in Unreal Engine with procedural terrain, biomes, and asset placement.</p>
+                  <a href="https://www.fab.com/pt-br/listings/5b18f63c-894d-40b8-846a-bf4670ee9eeb" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
+                </div>
+              </div>
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/ReplicatedExplosionPlugin.jpg" alt="Replicated Explosion Plugin cover" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">Replicated Explosion Plugin</h3>
+                  <p class="card3d-desc" data-i18n="plugins.explosion">Add fully replicated, network-ready explosions with customizable effects and optimized physics.</p>
+                  <a href="https://www.fab.com/pt-br/listings/13134d3a-256f-44bc-9052-3dd69e87932d" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
+                </div>
+              </div>
+              <div class="card3d card3d--placeholder" aria-hidden="true"></div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -172,9 +172,9 @@
       <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6" data-i18n="games.title">Our Games</h2>
       <p class="text-white/60 mb-6 max-w-3xl" data-i18n="games.subtitle">Worlds built with heart and cutting-edge tech. Use the arrows to explore.</p>
       <div class="relative">
-        <div class="services-slider" role="group" aria-roledescription="carousel" aria-label="Our Games" data-i18n-aria-label="games.title">
-          <div id="gamesTrack" class="services-track">
-            <div class="services-slide" aria-hidden="false">
+        <div class="carousel-window">
+          <div id="gamesTrack" class="carousel-track" role="group" aria-roledescription="carousel" aria-label="Our Games" data-i18n-aria-label="games.title">
+            <div class="carousel-slide" aria-hidden="false">
               <div class="card3d" data-card>
                 <div class="card3d-img"><img src="img/frontline.png" alt="Frontline key art" /></div>
                 <div class="p-5">
@@ -200,7 +200,7 @@
                 </div>
               </div>
             </div>
-            <div class="services-slide" aria-hidden="true">
+            <div class="carousel-slide" aria-hidden="true">
               <div class="card3d" data-card>
                 <div class="card3d-img"><img src="img/banapocalypse.png" alt="Bananapocalypse artwork" /></div>
                 <div class="p-5">

--- a/index.html
+++ b/index.html
@@ -172,9 +172,9 @@
       <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6" data-i18n="games.title">Our Games</h2>
       <p class="text-white/60 mb-6 max-w-3xl" data-i18n="games.subtitle">Worlds built with heart and cutting-edge tech. Use the arrows to explore.</p>
       <div class="relative">
-        <div class="carousel-window">
-          <div id="gamesTrack" class="carousel-track" role="group" aria-roledescription="carousel" aria-label="Our games carousel">
-            <div class="carousel-slide" aria-hidden="false">
+        <div class="services-slider" role="group" aria-roledescription="carousel" aria-label="Our Games" data-i18n-aria-label="games.title">
+          <div id="gamesTrack" class="services-track">
+            <div class="services-slide" aria-hidden="false">
               <div class="card3d" data-card>
                 <div class="card3d-img"><img src="img/frontline.png" alt="Frontline key art" /></div>
                 <div class="p-5">
@@ -200,7 +200,7 @@
                 </div>
               </div>
             </div>
-            <div class="carousel-slide" aria-hidden="true">
+            <div class="services-slide" aria-hidden="true">
               <div class="card3d" data-card>
                 <div class="card3d-img"><img src="img/banapocalypse.png" alt="Bananapocalypse artwork" /></div>
                 <div class="p-5">

--- a/js/script.js
+++ b/js/script.js
@@ -848,13 +848,27 @@
   }
 
   // Carousel controls
+  const focusableCarouselSelector = 'a, button, input, textarea, select, [tabindex]';
+  const toggleCarouselTabState = (el, active) => {
+    if (el.dataset.carouselTabindex === undefined){
+      const original = el.getAttribute('tabindex');
+      el.dataset.carouselTabindex = original === null ? '' : original;
+    }
+    if (!active){
+      el.setAttribute('tabindex', '-1');
+    } else {
+      const original = el.dataset.carouselTabindex;
+      if (original === '') el.removeAttribute('tabindex');
+      else el.setAttribute('tabindex', original);
+    }
+  };
+
   const setupPagedCarousel = (track, prevBtn, nextBtn) => {
     if (!track) return;
     const slides = $$('.carousel-slide', track);
     if (!slides.length) return;
 
     const total = slides.length;
-    const focusableSelector = 'a, button, input, textarea, select, [tabindex]';
 
     slides.forEach((slide, index) => {
       slide.setAttribute('role', 'group');
@@ -864,27 +878,13 @@
 
     let index = 0;
 
-    const restoreTabState = (el, active) => {
-      if (el.dataset.carouselTabindex === undefined){
-        const original = el.getAttribute('tabindex');
-        el.dataset.carouselTabindex = original === null ? '' : original;
-      }
-      if (!active){
-        el.setAttribute('tabindex', '-1');
-      } else {
-        const original = el.dataset.carouselTabindex;
-        if (original === '') el.removeAttribute('tabindex');
-        else el.setAttribute('tabindex', original);
-      }
-    };
-
     const update = () => {
       track.style.transform = `translateX(-${index * 100}%)`;
       slides.forEach((slide, slideIndex) => {
         const active = slideIndex === index;
         slide.setAttribute('aria-hidden', active ? 'false' : 'true');
         slide.style.pointerEvents = active ? 'auto' : 'none';
-        $$(focusableSelector, slide).forEach(el => restoreTabState(el, active));
+        $$(focusableCarouselSelector, slide).forEach(el => toggleCarouselTabState(el, active));
       });
       if (prevBtn) prevBtn.disabled = index === 0;
       if (nextBtn) nextBtn.disabled = index === total - 1;
@@ -910,41 +910,51 @@
     update();
   };
 
-  setupPagedCarousel(gamesTrack, $('#gamesPrev'), $('#gamesNext'));
   setupPagedCarousel(pluginsTrack, $('#pluginsPrev'), $('#pluginsNext'));
 
-  const setupServicesSlider = () => {
-    if (!servicesTrack) return null;
-    const slides = $$('.services-slide', servicesTrack);
-    if (!slides.length) return null;
-    let index = 0;
+  const setupLoopedCarousel = (track, prevBtn, nextBtn, slideSelector = '.services-slide') => {
+    if (!track) return;
+    const slides = $$(slideSelector, track);
+    if (!slides.length) return;
+
     const total = slides.length;
+    slides.forEach((slide, index) => {
+      slide.setAttribute('role', 'group');
+      slide.setAttribute('aria-roledescription', 'slide');
+      slide.setAttribute('aria-label', `${index + 1} / ${total}`);
+    });
+
+    let index = 0;
     const update = () => {
-      servicesTrack.style.transform = `translateX(-${index * 100}%)`;
-      slides.forEach((slide, i) => {
-        slide.setAttribute('aria-hidden', i === index ? 'false' : 'true');
+      track.style.transform = `translateX(-${index * 100}%)`;
+      slides.forEach((slide, slideIndex) => {
+        const active = slideIndex === index;
+        slide.setAttribute('aria-hidden', active ? 'false' : 'true');
+        slide.style.pointerEvents = active ? 'auto' : 'none';
+        $$(focusableCarouselSelector, slide).forEach(el => toggleCarouselTabState(el, active));
       });
     };
-    update();
-    return {
-      next(){
-        index = (index + 1) % total;
-        update();
-        blip(720, 0.05, 'triangle');
-      },
-      prev(){
-        index = (index - 1 + total) % total;
-        update();
-        blip(480, 0.05, 'triangle');
-      }
+
+    const goTo = (nextIndex) => {
+      index = (nextIndex + total) % total;
+      update();
     };
+
+    prevBtn && prevBtn.addEventListener('click', () => {
+      goTo(index - 1);
+      blip(480, 0.05, 'triangle');
+    });
+
+    nextBtn && nextBtn.addEventListener('click', () => {
+      goTo(index + 1);
+      blip(720, 0.05, 'triangle');
+    });
+
+    update();
   };
 
-  const servicesSlider = setupServicesSlider();
-  if (servicesSlider){
-    $('#servicesPrev')?.addEventListener('click', () => servicesSlider.prev());
-    $('#servicesNext')?.addEventListener('click', () => servicesSlider.next());
-  }
+  setupLoopedCarousel(gamesTrack, $('#gamesPrev'), $('#gamesNext'));
+  setupLoopedCarousel(servicesTrack, $('#servicesPrev'), $('#servicesNext'));
 
   // Hover SFX
   $$('#navbar a, #heroContent a').forEach(a => a.addEventListener('mouseenter', () => blip(800, 0.05)));

--- a/js/script.js
+++ b/js/script.js
@@ -49,7 +49,7 @@
       'flair.card3.title': 'Fearless Innovation',
       'flair.card3.copy': 'Proprietary Unreal Engine tools give us the edge to prototype fast and push the boundaries of gameplay.',
       'games.title': 'Our Games',
-      'games.subtitle': 'Worlds built with heart and cutting-edge tech. Drag to explore.',
+      'games.subtitle': 'Worlds built with heart and cutting-edge tech. Use the arrows to explore.',
       'games.frontline': 'An immersive tactical shooter combining realism, intensity, and storytelling — coming soon to Steam. Wishlist now.',
       'games.rampage': 'A musical brawler with a chaotic rhythm that offers pure adrenaline, destruction and chaos in multiplayer mode.',
       'games.dissociation': 'A psychological horror where an AI manipulates your every move — no weapons, no escape, only survival. Do you know what’s real?',
@@ -158,7 +158,7 @@
       'flair.card3.title': 'Inovação Destemida',
       'flair.card3.copy': 'Ferramentas proprietárias em Unreal Engine nos dão agilidade para prototipar rápido e expandir os limites do gameplay.',
       'games.title': 'Nossos Jogos',
-      'games.subtitle': 'Mundos construídos com coração e tecnologia de ponta. Arraste para explorar.',
+      'games.subtitle': 'Mundos construídos com coração e tecnologia de ponta. Use as setas para explorar.',
       'games.frontline': 'Um shooter tático imersivo que combina realismo, intensidade e narrativa — em breve na Steam. Adicione à lista de desejos.',
       'games.rampage': 'Um brawler musical de ritmo caótico que entrega adrenalina, destruição e caos no modo multiplayer.',
       'games.dissociation': 'Um terror psicológico em que uma IA manipula cada movimento seu — sem armas, sem escape, só sobrevivência. Você sabe o que é real?',
@@ -267,7 +267,7 @@
       'flair.card3.title': 'Innovación Sin Miedo',
       'flair.card3.copy': 'Herramientas propietarias en Unreal Engine nos permiten prototipar rápido y empujar los límites del gameplay.',
       'games.title': 'Nuestros Juegos',
-      'games.subtitle': 'Mundos construidos con corazón y tecnología de punta. Arrastra para explorar.',
+      'games.subtitle': 'Mundos construidos con corazón y tecnología de punta. Usa las flechas para explorar.',
       'games.frontline': 'Un shooter táctico inmersivo que combina realismo, intensidad y narrativa — muy pronto en Steam. Agrégalo a tu lista de deseados.',
       'games.rampage': 'Un brawler musical con un ritmo caótico que ofrece adrenalina pura, destrucción y caos en modo multijugador.',
       'games.dissociation': 'Un terror psicológico donde una IA manipula cada uno de tus movimientos — sin armas, sin escape, solo supervivencia. ¿Sabes qué es real?',
@@ -376,7 +376,7 @@
       'flair.card3.title': '无惧创新',
       'flair.card3.copy': '自研的 Unreal Engine 工具让我们快速原型迭代，不断突破玩法边界。',
       'games.title': '我们的游戏',
-      'games.subtitle': '用热忱与尖端科技构建的世界。拖动浏览。',
+      'games.subtitle': '用热忱与尖端科技构建的世界。点击箭头浏览。',
       'games.frontline': '一款将真实感、张力与叙事融合的沉浸式战术射击——即将登陆 Steam，立即加入愿望单。',
       'games.rampage': '一款节奏混乱的音乐格斗游戏，在多人模式中带来纯粹的肾上腺素、破坏与混乱。',
       'games.dissociation': '一部心理恐怖作品，AI 操控你的每一步——无武器、无逃脱，只有求生。你还能分辨真实吗？',
@@ -485,7 +485,7 @@
       'flair.card3.title': '恐れないイノベーション',
       'flair.card3.copy': '自社の Unreal Engine ツールで素早くプロトタイプを作り、ゲームプレイの限界に挑み続けます。',
       'games.title': '私たちのゲーム',
-      'games.subtitle': '情熱と最先端技術で作り上げた世界。ドラッグしてご覧ください。',
+      'games.subtitle': '情熱と最先端技術で作り上げた世界。矢印でスクロールしてください。',
       'games.frontline': 'リアリズム、緊張感、物語性を融合させた没入型タクティカルシューター — まもなく Steam で配信予定。ウィッシュリストに登録しよう。',
       'games.rampage': '混沌としたリズムで展開する音楽系乱闘ゲーム。マルチプレイで純粋な興奮と破壊、カオスを体験。',
       'games.dissociation': 'AI があなたの一挙手一投足を操るサイコホラー — 武器も逃げ場もなく、生き残りだけが目的。現実を見分けられますか？',
@@ -848,17 +848,70 @@
   }
 
   // Carousel controls
-  const scrollByCard = (track, dir=1) => {
+  const setupPagedCarousel = (track, prevBtn, nextBtn) => {
     if (!track) return;
-    const card = track.querySelector('[data-card]');
-    const amount = card ? card.clientWidth + 16 : 320;
-    track.scrollBy({ left: amount * dir, behavior:'smooth' });
-    blip(dir>0 ? 720 : 480, 0.05, 'triangle');
+    const slides = $$('.carousel-slide', track);
+    if (!slides.length) return;
+
+    const total = slides.length;
+    const focusableSelector = 'a, button, input, textarea, select, [tabindex]';
+
+    slides.forEach((slide, index) => {
+      slide.setAttribute('role', 'group');
+      slide.setAttribute('aria-roledescription', 'slide');
+      slide.setAttribute('aria-label', `${index + 1} / ${total}`);
+    });
+
+    let index = 0;
+
+    const restoreTabState = (el, active) => {
+      if (el.dataset.carouselTabindex === undefined){
+        const original = el.getAttribute('tabindex');
+        el.dataset.carouselTabindex = original === null ? '' : original;
+      }
+      if (!active){
+        el.setAttribute('tabindex', '-1');
+      } else {
+        const original = el.dataset.carouselTabindex;
+        if (original === '') el.removeAttribute('tabindex');
+        else el.setAttribute('tabindex', original);
+      }
+    };
+
+    const update = () => {
+      track.style.transform = `translateX(-${index * 100}%)`;
+      slides.forEach((slide, slideIndex) => {
+        const active = slideIndex === index;
+        slide.setAttribute('aria-hidden', active ? 'false' : 'true');
+        slide.style.pointerEvents = active ? 'auto' : 'none';
+        $$(focusableSelector, slide).forEach(el => restoreTabState(el, active));
+      });
+      if (prevBtn) prevBtn.disabled = index === 0;
+      if (nextBtn) nextBtn.disabled = index === total - 1;
+    };
+
+    const goTo = (nextIndex) => {
+      index = nextIndex;
+      update();
+    };
+
+    prevBtn && prevBtn.addEventListener('click', () => {
+      if (index === 0) return;
+      goTo(index - 1);
+      blip(480, 0.05, 'triangle');
+    });
+
+    nextBtn && nextBtn.addEventListener('click', () => {
+      if (index >= total - 1) return;
+      goTo(index + 1);
+      blip(720, 0.05, 'triangle');
+    });
+
+    update();
   };
-  $('#gamesPrev')?.addEventListener('click', () => scrollByCard(gamesTrack, -1));
-  $('#gamesNext')?.addEventListener('click', () => scrollByCard(gamesTrack, 1));
-  $('#pluginsPrev')?.addEventListener('click', () => scrollByCard(pluginsTrack, -1));
-  $('#pluginsNext')?.addEventListener('click', () => scrollByCard(pluginsTrack, 1));
+
+  setupPagedCarousel(gamesTrack, $('#gamesPrev'), $('#gamesNext'));
+  setupPagedCarousel(pluginsTrack, $('#pluginsPrev'), $('#pluginsNext'));
 
   const setupServicesSlider = () => {
     if (!servicesTrack) return null;

--- a/js/script.js
+++ b/js/script.js
@@ -953,7 +953,7 @@
     update();
   };
 
-  setupLoopedCarousel(gamesTrack, $('#gamesPrev'), $('#gamesNext'));
+  setupLoopedCarousel(gamesTrack, $('#gamesPrev'), $('#gamesNext'), '.carousel-slide');
   setupLoopedCarousel(servicesTrack, $('#servicesPrev'), $('#servicesNext'));
 
   // Hover SFX


### PR DESCRIPTION
## Summary
- reworked the Our Games and Our Plugins sections to use paginated carousels that present three cards per page and keep the layout consistent with placeholders
- added responsive carousel styling and disabled-state visuals for the navigation arrows
- updated the carousel script to manage slides/focus and refreshed multilingual subtitles to reference arrow navigation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ed618291a0832f8cea0ce3585dc182