### PR TITLE
Replicate service slider layout for plugins section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -143,7 +143,7 @@ section[id] {
   .carousel-controls{ top:100%; left:0; right:0; transform:none; margin-top:.75rem; justify-content:center; gap:.75rem; }
 }
 
-#gamesTrack, #pluginsTrack{ scroll-snap-type:x proximity; padding-bottom:.5rem; }
+#gamesTrack{ scroll-snap-type:x proximity; padding-bottom:.5rem; }
 
 /* News cards */
 .news-card{ border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:linear-gradient(135deg, rgba(255,255,255,.05), transparent); }
@@ -308,8 +308,7 @@ section[id] {
 
 /* Responsive Cards */
 @media (max-width: 640px){
-  #gamesTrack,
-  #pluginsTrack{
+  #gamesTrack{
     display:flex;
     flex-direction:column;
     align-items:stretch;
@@ -385,7 +384,7 @@ section[id] {
 
 @media (min-width: 1024px){
   .hero-section{ min-height:88vh; }
-  #gamesTrack, #pluginsTrack{ justify-content:center; }
+  #gamesTrack{ justify-content:center; }
 }
 
 @media (prefers-reduced-motion: reduce){

--- a/index.html
+++ b/index.html
@@ -293,21 +293,26 @@
         <span class="text-xs text-purple-300/70" data-i18n="plugins.subtitle">Fab marketplace listings</span>
       </div>
       <div class="relative">
-        <div id="pluginsTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/WorldProceduralGeneratorPlugin.jpg" alt="World Procedural Generator Plugin cover" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">World Procedural Generator Plugin</h3>
-              <p class="card3d-desc" data-i18n="plugins.world">Create vast and dynamic open worlds in Unreal Engine with procedural terrain, biomes, and asset placement.</p>
-              <a href="https://www.fab.com/pt-br/listings/5b18f63c-894d-40b8-846a-bf4670ee9eeb" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
-            </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/ReplicatedExplosionPlugin.jpg" alt="Replicated Explosion Plugin cover" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Replicated Explosion Plugin</h3>
-              <p class="card3d-desc" data-i18n="plugins.explosion">Add fully replicated, network-ready explosions with customizable effects and optimized physics.</p>
-              <a href="https://www.fab.com/pt-br/listings/13134d3a-256f-44bc-9052-3dd69e87932d" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
+        <div class="services-slider" role="group" aria-roledescription="carousel" aria-label="Our Plugins" data-i18n-aria-label="plugins.title">
+          <div id="pluginsTrack" class="services-track">
+            <div class="services-slide" aria-hidden="false">
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/WorldProceduralGeneratorPlugin.jpg" alt="World Procedural Generator Plugin cover" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">World Procedural Generator Plugin</h3>
+                  <p class="card3d-desc" data-i18n="plugins.world">Create vast and dynamic open worlds in Unreal Engine with procedural terrain, biomes, and asset placement.</p>
+                  <a href="https://www.fab.com/pt-br/listings/5b18f63c-894d-40b8-846a-bf4670ee9eeb" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
+                </div>
+              </div>
+              <div class="card3d" data-card>
+                <div class="card3d-img"><img src="img/ReplicatedExplosionPlugin.jpg" alt="Replicated Explosion Plugin cover" /></div>
+                <div class="p-5">
+                  <h3 class="card3d-title">Replicated Explosion Plugin</h3>
+                  <p class="card3d-desc" data-i18n="plugins.explosion">Add fully replicated, network-ready explosions with customizable effects and optimized physics.</p>
+                  <a href="https://www.fab.com/pt-br/listings/13134d3a-256f-44bc-9052-3dd69e87932d" target="_blank" rel="noopener" class="card3d-link" data-i18n="plugins.view">View Plugin →</a>
+                </div>
+              </div>
+              <div class="card3d card3d--placeholder" aria-hidden="true"></div>
             </div>
           </div>
         </div>

--- a/js/script.js
+++ b/js/script.js
@@ -857,17 +857,15 @@
   };
   $('#gamesPrev')?.addEventListener('click', () => scrollByCard(gamesTrack, -1));
   $('#gamesNext')?.addEventListener('click', () => scrollByCard(gamesTrack, 1));
-  $('#pluginsPrev')?.addEventListener('click', () => scrollByCard(pluginsTrack, -1));
-  $('#pluginsNext')?.addEventListener('click', () => scrollByCard(pluginsTrack, 1));
 
-  const setupServicesSlider = () => {
-    if (!servicesTrack) return null;
-    const slides = $$('.services-slide', servicesTrack);
+  const setupSlider = (track) => {
+    if (!track) return null;
+    const slides = $$('.services-slide', track);
     if (!slides.length) return null;
     let index = 0;
     const total = slides.length;
     const update = () => {
-      servicesTrack.style.transform = `translateX(-${index * 100}%)`;
+      track.style.transform = `translateX(-${index * 100}%)`;
       slides.forEach((slide, i) => {
         slide.setAttribute('aria-hidden', i === index ? 'false' : 'true');
       });
@@ -887,10 +885,16 @@
     };
   };
 
-  const servicesSlider = setupServicesSlider();
+  const servicesSlider = setupSlider(servicesTrack);
   if (servicesSlider){
     $('#servicesPrev')?.addEventListener('click', () => servicesSlider.prev());
     $('#servicesNext')?.addEventListener('click', () => servicesSlider.next());
+  }
+
+  const pluginsSlider = setupSlider(pluginsTrack);
+  if (pluginsSlider){
+    $('#pluginsPrev')?.addEventListener('click', () => pluginsSlider.prev());
+    $('#pluginsNext')?.addEventListener('click', () => pluginsSlider.next());
   }
 
   // Hover SFX


### PR DESCRIPTION
## Summary
- replace the plugins section markup with the carousel layout used by Service Collaborations so three cards are shown per slide
- generalize the slider controller in script.js to support both the services and plugins carousels
- remove the old scroll styles tied to #pluginsTrack so the new slider inherits the shared carousel styling

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ed6c869614832f8d3e5e7aa8165b75