### PR TITLE
Refine Our Games carousel to mirror services slider

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -143,7 +143,7 @@ section[id] {
   .carousel-controls{ top:100%; left:0; right:0; transform:none; margin-top:.75rem; justify-content:center; gap:.75rem; }
 }
 
-#gamesTrack{ scroll-snap-type:x proximity; padding-bottom:.5rem; }
+#gamesTrack{ padding-bottom:.5rem; }
 
 /* News cards */
 .news-card{ border:1px solid rgba(255,255,255,.1); padding:1.5rem; border-radius:.75rem; background:linear-gradient(135deg, rgba(255,255,255,.05), transparent); }

--- a/index.html
+++ b/index.html
@@ -172,39 +172,8 @@
       <h2 class="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6" data-i18n="games.title">Our Games</h2>
       <p class="text-white/60 mb-6 max-w-3xl" data-i18n="games.subtitle">Worlds built with heart and cutting-edge tech. Drag to explore.</p>
       <div class="relative">
-        <div id="gamesTrack" class="flex flex-col sm:flex-row gap-4 overflow-visible sm:overflow-x-auto no-scrollbar pb-2">
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/frontline.png" alt="Frontline key art" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Frontline</h3>
-              <p class="card3d-desc" data-i18n="games.frontline">An immersive tactical shooter combining realism, intensity, and storytelling — coming soon to Steam. Wishlist now.</p>
-              <a href="https://store.steampowered.com/app/1772220/Frontline_New_Revolution/" target="_blank" rel="noopener" class="card3d-link" data-i18n="shared.learnMore">Learn More →</a>
-            </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/rampagerush.jpg" alt="Rampage Rush concept art" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Rampage Rush</h3>
-              <p class="card3d-desc" data-i18n="games.rampage">A musical brawler with a chaotic rhythm that offers pure adrenaline, destruction and chaos in multiplayer mode.</p>
-              <!-- <a href="#" class="card3d-link">Learn More →</a> -->
-            </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/dissociation.jpg" alt="Bananapocalypse artwork" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Dissociation</h3>
-              <p class="card3d-desc" data-i18n="games.dissociation">A psychological horror where an AI manipulates your every move — no weapons, no escape, only survival. Do you know what’s real?</p>
-              <!-- <a href="#" class="card3d-link">Learn More →</a> -->
-            </div>
-          </div>
-          <div class="card3d" data-card>
-            <div class="card3d-img"><img src="img/banapocalypse.png" alt="Bananapocalypse artwork" /></div>
-            <div class="p-5">
-              <h3 class="card3d-title">Bananapocalypse</h3>
-              <p class="card3d-desc" data-i18n="games.banana">Um jogo co-op onde todos os jogadores são macacos fugindo de um laboratório — todos precisam correr e escapar enquanto fazem macacagens.</p>
-              <!-- <a href="#" class="card3d-link">Learn More →</a> -->
-            </div>
-          </div>
+        <div class="services-slider" role="group" aria-roledescription="carousel" aria-label="Our Games" data-i18n-aria-label="games.title">
+          <div id="gamesTrack" class="services-track" data-per-slide="3"></div>
         </div>
         <div class="carousel-controls">
           <button id="gamesPrev" aria-label="Previous" data-i18n-aria-label="carousel.prev">‹</button>

--- a/js/script.js
+++ b/js/script.js
@@ -22,6 +22,37 @@
   const formError = $('#formError');
   const sendBtn = $('#sendBtn');
 
+  const gameCards = [
+    {
+      title: 'Frontline',
+      image: 'img/frontline.png',
+      alt: 'Frontline key art',
+      descKey: 'games.frontline',
+      link: {
+        href: 'https://store.steampowered.com/app/1772220/Frontline_New_Revolution/',
+        labelKey: 'shared.learnMore'
+      }
+    },
+    {
+      title: 'Rampage Rush',
+      image: 'img/rampagerush.jpg',
+      alt: 'Rampage Rush concept art',
+      descKey: 'games.rampage'
+    },
+    {
+      title: 'Dissociation',
+      image: 'img/dissociation.jpg',
+      alt: 'Dissociation artwork',
+      descKey: 'games.dissociation'
+    },
+    {
+      title: 'Bananapocalypse',
+      image: 'img/banapocalypse.png',
+      alt: 'Bananapocalypse artwork',
+      descKey: 'games.banana'
+    }
+  ];
+
   const translations = {
     en: {
       'nav.games': 'Games',
@@ -588,6 +619,86 @@
 
   let muted = true;
 
+  const buildGamesCarousel = () => {
+    if (!gamesTrack) return;
+    const perSlideAttr = parseInt(gamesTrack.dataset.perSlide || '3', 10);
+    const perSlide = Number.isFinite(perSlideAttr) && perSlideAttr > 0 ? perSlideAttr : 3;
+    gamesTrack.innerHTML = '';
+
+    const createGameCard = (card) => {
+      const cardEl = document.createElement('div');
+      cardEl.className = 'card3d';
+      cardEl.dataset.card = '';
+
+      const media = document.createElement('div');
+      media.className = 'card3d-img';
+      const img = document.createElement('img');
+      img.src = card.image;
+      img.alt = card.alt || '';
+      media.appendChild(img);
+      cardEl.appendChild(media);
+
+      const body = document.createElement('div');
+      body.className = 'p-5';
+
+      const title = document.createElement('h3');
+      title.className = 'card3d-title';
+      title.textContent = card.title;
+      body.appendChild(title);
+
+      if (card.descKey){
+        const desc = document.createElement('p');
+        desc.className = 'card3d-desc';
+        desc.dataset.i18n = card.descKey;
+        desc.textContent = translations.en?.[card.descKey] || '';
+        body.appendChild(desc);
+      }
+
+      if (card.link){
+        const link = document.createElement('a');
+        link.className = 'card3d-link';
+        link.href = card.link.href;
+        if (card.link.target !== '_self'){
+          link.target = '_blank';
+          link.rel = 'noopener';
+        }
+        if (card.link.labelKey){
+          link.dataset.i18n = card.link.labelKey;
+          link.textContent = translations.en?.[card.link.labelKey] || 'Learn More →';
+        } else if (card.link.label){
+          link.textContent = card.link.label;
+        }
+        body.appendChild(link);
+      }
+
+      cardEl.appendChild(body);
+      return cardEl;
+    };
+
+    const slides = [];
+    for (let i = 0; i < gameCards.length; i += perSlide){
+      slides.push(gameCards.slice(i, i + perSlide));
+    }
+    if (!slides.length) slides.push([]);
+
+    slides.forEach((cards, index) => {
+      const slide = document.createElement('div');
+      slide.className = 'services-slide';
+      slide.setAttribute('aria-hidden', index === 0 ? 'false' : 'true');
+      cards.forEach(card => slide.appendChild(createGameCard(card)));
+
+      const placeholdersNeeded = Math.max(0, perSlide - cards.length);
+      for (let i = 0; i < placeholdersNeeded; i++){
+        const placeholder = document.createElement('div');
+        placeholder.className = 'card3d card3d--placeholder';
+        placeholder.setAttribute('aria-hidden', 'true');
+        slide.appendChild(placeholder);
+      }
+
+      gamesTrack.appendChild(slide);
+    });
+  };
+
   const createServiceImages = () => {
     $$('[data-service-image]').forEach(slot => {
       const src = (slot.dataset.serviceImage || '').trim();
@@ -654,6 +765,7 @@
     refreshMuteBtn();
   };
 
+  buildGamesCarousel();
   createServiceImages();
   applyTranslations(currentLang);
 
@@ -847,17 +959,6 @@
     });
   }
 
-  // Carousel controls
-  const scrollByCard = (track, dir=1) => {
-    if (!track) return;
-    const card = track.querySelector('[data-card]');
-    const amount = card ? card.clientWidth + 16 : 320;
-    track.scrollBy({ left: amount * dir, behavior:'smooth' });
-    blip(dir>0 ? 720 : 480, 0.05, 'triangle');
-  };
-  $('#gamesPrev')?.addEventListener('click', () => scrollByCard(gamesTrack, -1));
-  $('#gamesNext')?.addEventListener('click', () => scrollByCard(gamesTrack, 1));
-
   const setupSlider = (track) => {
     if (!track) return null;
     const slides = $$('.services-slide', track);
@@ -884,6 +985,12 @@
       }
     };
   };
+
+  const gamesSlider = setupSlider(gamesTrack);
+  if (gamesSlider){
+    $('#gamesPrev')?.addEventListener('click', () => gamesSlider.prev());
+    $('#gamesNext')?.addEventListener('click', () => gamesSlider.next());
+  }
 
   const servicesSlider = setupSlider(servicesTrack);
   if (servicesSlider){


### PR DESCRIPTION
## Summary
- rebuild the Our Games markup to share the services slider structure with a dynamic track container
- generate three-card slides in script.js from a single games data list so each page mirrors the service collaborations carousel

## Testing
- npx --yes prettier --check index.html css/style.css js/script.js *(fails: repository not formatted with Prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68ed7605cde8832fa5e42528ecf25516